### PR TITLE
CVSB-8592 - reimplement CVSB-7623: filter on testStatus

### DIFF
--- a/src/functions/getTestResultsByTesterStaffId.ts
+++ b/src/functions/getTestResultsByTesterStaffId.ts
@@ -43,7 +43,11 @@ export const getTestResultsByTesterStaffId = async (event: any) => {
       }
     }
 
-    return testResultsService.getTestResults({ testerStaffId, testStationPNumber, fromDateTime, toDateTime })
+    const filters: any = { testerStaffId, testStationPNumber, fromDateTime, toDateTime };
+    if (event.queryStringParameters.testStatus) {
+      filters.testStatus = event.queryStringParameters.testStatus;
+    }
+    return testResultsService.getTestResults(filters)
       .then((data: any) => {
         return new HTTPResponse(200, data);
       })

--- a/src/models/ITestResultFilter.ts
+++ b/src/models/ITestResultFilter.ts
@@ -4,4 +4,5 @@ export interface ITestResultFilters {
     toDateTime?: any;
     testerStaffId?: any;
     testStationPNumber?: any;
+    status?: string;
 }


### PR DESCRIPTION
CVSB-7623 got lost during Typescript Migration. Reimplementing here. No other changes.