### PR TITLE
CVSB-8658: Update the logic of First test expiry date generation for …

### DIFF
--- a/src/models/ITestResult.ts
+++ b/src/models/ITestResult.ts
@@ -26,6 +26,6 @@ export interface ITestResult   {
     noOfAxles: string;
     testerEmailAddress: string;
     euVehicleCategory: string;
-    regnDate: string
-    firstUseDate: string
+    regnDate: string;
+    firstUseDate: string;
   }

--- a/src/models/ITestResult.ts
+++ b/src/models/ITestResult.ts
@@ -26,4 +26,6 @@ export interface ITestResult   {
     noOfAxles: string;
     testerEmailAddress: string;
     euVehicleCategory: string;
+    regnDate: string
+    firstUseDate: string
   }

--- a/src/models/ITestResultPayload.ts
+++ b/src/models/ITestResultPayload.ts
@@ -9,4 +9,6 @@ export interface ITestResultPayload {
     testResultId?: string;
     vehicleId?: string;
     vrm?: string;
+    regnDate: string;
+    firstUseDate: string;
 }

--- a/src/models/TestResultsSchemaHGVCancelled.ts
+++ b/src/models/TestResultsSchemaHGVCancelled.ts
@@ -34,7 +34,7 @@ const testResultsSchema = Joi.object().keys({
     countryOfRegistration: Joi.string().required().allow("", null),
     vehicleConfiguration: Joi.any().only(["rigid", "articulated", "centre axle drawbar", "semi-car transporter", "semi-trailer", "low loader", "other", "drawbar", "four-in-line", "dolly", "full drawbar"]).required(),
     testTypes: Joi.array().items(testTypesSchema).required(),
-    regnDate: Joi.string().required().allow("", null)
+    regnDate: Joi.string().allow("", null)
 });
 
 export default testResultsSchema;

--- a/src/models/TestResultsSchemaHGVCancelled.ts
+++ b/src/models/TestResultsSchemaHGVCancelled.ts
@@ -33,7 +33,8 @@ const testResultsSchema = Joi.object().keys({
     euVehicleCategory: Joi.any().only(["m1", "m2", "m3", "n1", "n2", "n3", "o1", "o2", "o3", "o4"]).required().allow(null),
     countryOfRegistration: Joi.string().required().allow("", null),
     vehicleConfiguration: Joi.any().only(["rigid", "articulated", "centre axle drawbar", "semi-car transporter", "semi-trailer", "low loader", "other", "drawbar", "four-in-line", "dolly", "full drawbar"]).required(),
-    testTypes: Joi.array().items(testTypesSchema).required()
+    testTypes: Joi.array().items(testTypesSchema).required(),
+    regnDate: Joi.string().required().allow("", null)
 });
 
 export default testResultsSchema;

--- a/src/models/TestResultsSchemaHGVSubmitted.ts
+++ b/src/models/TestResultsSchemaHGVSubmitted.ts
@@ -33,7 +33,8 @@ const testResultsSchema = Joi.object().keys({
     euVehicleCategory: Joi.any().only(["m1", "m2", "m3", "n1", "n2", "n3", "o1", "o2", "o3", "o4"]).required(),
     countryOfRegistration: Joi.string().required().allow(""),
     vehicleConfiguration: Joi.any().only(["rigid", "articulated", "centre axle drawbar", "semi-car transporter", "semi-trailer", "low loader", "other", "drawbar", "four-in-line", "dolly", "full drawbar"]).required(),
-    testTypes: Joi.array().items(testTypesSchema).required()
+    testTypes: Joi.array().items(testTypesSchema).required(),
+    regnDate: Joi.string().required().allow("", null)
 });
 
 export default testResultsSchema;

--- a/src/models/TestResultsSchemaHGVSubmitted.ts
+++ b/src/models/TestResultsSchemaHGVSubmitted.ts
@@ -34,7 +34,7 @@ const testResultsSchema = Joi.object().keys({
     countryOfRegistration: Joi.string().required().allow(""),
     vehicleConfiguration: Joi.any().only(["rigid", "articulated", "centre axle drawbar", "semi-car transporter", "semi-trailer", "low loader", "other", "drawbar", "four-in-line", "dolly", "full drawbar"]).required(),
     testTypes: Joi.array().items(testTypesSchema).required(),
-    regnDate: Joi.string().required().allow("", null)
+    regnDate: Joi.string().allow("", null)
 });
 
 export default testResultsSchema;

--- a/src/models/TestResultsSchemaTRLCancelled.ts
+++ b/src/models/TestResultsSchemaTRLCancelled.ts
@@ -31,7 +31,8 @@ const testResultsSchema = Joi.object().keys({
     countryOfRegistration: Joi.string().required().allow("", null),
     vehicleConfiguration: Joi.any().only(["rigid", "articulated", "centre axle drawbar", "semi-car transporter", "semi-trailer", "low loader", "other", "drawbar", "four-in-line", "dolly", "full drawbar"]).required(),
     trailerId: Joi.string().required(),
-    testTypes: Joi.array().items(testTypesSchema).required()
+    testTypes: Joi.array().items(testTypesSchema).required(),
+    firstUseDate: Joi.string().required().allow("", null)
 });
 
 export default testResultsSchema;

--- a/src/models/TestResultsSchemaTRLCancelled.ts
+++ b/src/models/TestResultsSchemaTRLCancelled.ts
@@ -32,7 +32,7 @@ const testResultsSchema = Joi.object().keys({
     vehicleConfiguration: Joi.any().only(["rigid", "articulated", "centre axle drawbar", "semi-car transporter", "semi-trailer", "low loader", "other", "drawbar", "four-in-line", "dolly", "full drawbar"]).required(),
     trailerId: Joi.string().required(),
     testTypes: Joi.array().items(testTypesSchema).required(),
-    firstUseDate: Joi.string().required().allow("", null)
+    firstUseDate: Joi.string().allow("", null)
 });
 
 export default testResultsSchema;

--- a/src/models/TestResultsSchemaTRLSubmitted.ts
+++ b/src/models/TestResultsSchemaTRLSubmitted.ts
@@ -31,7 +31,8 @@ const testResultsSchema = Joi.object().keys({
     countryOfRegistration: Joi.string().required().allow(""),
     vehicleConfiguration: Joi.any().only(["rigid", "articulated", "centre axle drawbar", "semi-car transporter", "semi-trailer", "low loader", "other", "drawbar", "four-in-line", "dolly", "full drawbar"]).required(),
     trailerId: Joi.string().required(),
-    testTypes: Joi.array().items(testTypesSchema).required()
+    testTypes: Joi.array().items(testTypesSchema).required(),
+    firstUseDate: Joi.string().required().allow("", null)
 });
 
 export default testResultsSchema;

--- a/src/models/TestResultsSchemaTRLSubmitted.ts
+++ b/src/models/TestResultsSchemaTRLSubmitted.ts
@@ -32,7 +32,7 @@ const testResultsSchema = Joi.object().keys({
     vehicleConfiguration: Joi.any().only(["rigid", "articulated", "centre axle drawbar", "semi-car transporter", "semi-trailer", "low loader", "other", "drawbar", "four-in-line", "dolly", "full drawbar"]).required(),
     trailerId: Joi.string().required(),
     testTypes: Joi.array().items(testTypesSchema).required(),
-    firstUseDate: Joi.string().required().allow("", null)
+    firstUseDate: Joi.string().allow("", null)
 });
 
 export default testResultsSchema;

--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -260,14 +260,14 @@ export class TestResultsService {
         .then((mostRecentExpiryDateOnAllTestTypesByVin) => {
           payload.testTypes.forEach((testType: any, index: number) => {
             if (testType.testTypeClassification === "Annual With Certificate" &&
-              (testType.testResult === "pass" || testType.testResult === "prs" || testType.testResult === "fail")) {
+                (testType.testResult === "pass" || testType.testResult === "prs" || testType.testResult === "fail")) {
               testType.certificateNumber = testType.testNumber;
               payload.testTypes[index] = testType;
               if (testType.testResult !== "fail") {
-                if (payload.vehicleType === VEHICLE_TYPES.PSV ) {
+                if (payload.vehicleType === VEHICLE_TYPES.PSV) {
                   if (dateFns.isEqual(mostRecentExpiryDateOnAllTestTypesByVin, new Date(1970, 1, 1))
-                    || dateFns.isBefore(mostRecentExpiryDateOnAllTestTypesByVin, dateFns.startOfDay(new Date()))
-                    || dateFns.isAfter(mostRecentExpiryDateOnAllTestTypesByVin, dateFns.addMonths(new Date(), 2))) {
+                      || dateFns.isBefore(mostRecentExpiryDateOnAllTestTypesByVin, dateFns.startOfDay(new Date()))
+                      || dateFns.isAfter(mostRecentExpiryDateOnAllTestTypesByVin, dateFns.addMonths(new Date(), 2))) {
                     testType.testExpiryDate = dateFns.subDays(dateFns.addYears(new Date(), 1), 1).toISOString();
                     payload.testTypes[index] = testType;
                   } else if (dateFns.isToday(mostRecentExpiryDateOnAllTestTypesByVin)) {
@@ -278,11 +278,29 @@ export class TestResultsService {
                     payload.testTypes[index] = testType;
                   }
                 } else if (payload.vehicleType === VEHICLE_TYPES.HGV || payload.vehicleType === VEHICLE_TYPES.TRL) {
+                  // Checks for testType = First test or First test Retest AND if vehicle doesn't currently have an existing expiry date, i.e set to default
+                  if (this.isFirstTestRetestTestType(testType) && dateFns.isEqual(mostRecentExpiryDateOnAllTestTypesByVin, new Date(1970, 1, 1))) {
+                    // Applying CVSB-8658 logic changes if vehicle doesn't currently have an existing expiry date
+                    const regOrFirstUseDate = payload.vehicleType === VEHICLE_TYPES.HGV ? payload.regnDate : payload.firstUseDate;
+                    const anvDateForCompare = regOrFirstUseDate ? dateFns.addYears(dateFns.lastDayOfMonth(regOrFirstUseDate), 1).toISOString() : undefined;
+                    console.log(`Test Date: ${new Date()}, Anv Date: ${anvDateForCompare}`);
+                    // If anniversaryDate is not populated in tech-records OR test date is 2 months or more before the Registration/First Use Anniversary for HGV/TRL
+                    if(!anvDateForCompare || dateFns.isBefore(new  Date(), dateFns.subMonths(anvDateForCompare, 2))){
+                      testType.testExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1).toISOString();
+                      console.log(`Setting expiryDate: ${testType.testExpiryDate}`);
+                    }else {
+                      // less than 2 months then set expiryDate 1 year after the Registration/First Use Anniversary date
+                      testType.testExpiryDate = dateFns.addYears(anvDateForCompare, 1).toISOString();
+                      console.log(`Setting expiryDate 1yr after AnvDate: ${testType.testExpiryDate}`);
+                    }
+                  } else {
                     if (dateFns.isAfter(mostRecentExpiryDateOnAllTestTypesByVin, new Date()) && dateFns.isBefore(mostRecentExpiryDateOnAllTestTypesByVin, dateFns.addMonths(new Date(), 2))) {
                       testType.testExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(mostRecentExpiryDateOnAllTestTypesByVin), 1).toISOString();
                     } else {
                       testType.testExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1).toISOString();
                     }
+                  }
+                  payload.testTypes[index] = testType;
                 }
               }
             }
@@ -296,6 +314,10 @@ export class TestResultsService {
     }
   }
 
+  public isFirstTestRetestTestType(testType: any): boolean {
+    const adrTestTypeIds = ["95", "41", "64", "102"];
+    return adrTestTypeIds.includes(testType.testTypeId)
+  }
   public getMostRecentExpiryDateOnAllTestTypesByVin(vin: any) {
     let maxDate = new Date(1970, 1, 1);
     return this.getTestResults({ vin, testStatus: "submitted", fromDateTime: new Date(1970, 1, 1), toDateTime: new Date() })

--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -283,15 +283,12 @@ export class TestResultsService {
                     // Applying CVSB-8658 logic changes if vehicle doesn't currently have an existing expiry date
                     const regOrFirstUseDate = payload.vehicleType === VEHICLE_TYPES.HGV ? payload.regnDate : payload.firstUseDate;
                     const anvDateForCompare = regOrFirstUseDate ? dateFns.addYears(dateFns.lastDayOfMonth(regOrFirstUseDate), 1).toISOString() : undefined;
-                    console.log(`Test Date: ${new Date()}, Anv Date: ${anvDateForCompare}`);
                     // If anniversaryDate is not populated in tech-records OR test date is 2 months or more before the Registration/First Use Anniversary for HGV/TRL
                     if (!anvDateForCompare || dateFns.isBefore(new  Date(), dateFns.subMonths(anvDateForCompare, 2))) {
                       testType.testExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1).toISOString();
-                      console.log(`Setting expiryDate: ${testType.testExpiryDate}`);
                     } else {
                       // less than 2 months then set expiryDate 1 year after the Registration/First Use Anniversary date
                       testType.testExpiryDate = dateFns.addYears(anvDateForCompare, 1).toISOString();
-                      console.log(`Setting expiryDate 1yr after AnvDate: ${testType.testExpiryDate}`);
                     }
                   } else {
                     if (dateFns.isAfter(mostRecentExpiryDateOnAllTestTypesByVin, new Date()) && dateFns.isBefore(mostRecentExpiryDateOnAllTestTypesByVin, dateFns.addMonths(new Date(), 2))) {

--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -285,10 +285,10 @@ export class TestResultsService {
                     const anvDateForCompare = regOrFirstUseDate ? dateFns.addYears(dateFns.lastDayOfMonth(regOrFirstUseDate), 1).toISOString() : undefined;
                     console.log(`Test Date: ${new Date()}, Anv Date: ${anvDateForCompare}`);
                     // If anniversaryDate is not populated in tech-records OR test date is 2 months or more before the Registration/First Use Anniversary for HGV/TRL
-                    if(!anvDateForCompare || dateFns.isBefore(new  Date(), dateFns.subMonths(anvDateForCompare, 2))){
+                    if (!anvDateForCompare || dateFns.isBefore(new  Date(), dateFns.subMonths(anvDateForCompare, 2))) {
                       testType.testExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1).toISOString();
                       console.log(`Setting expiryDate: ${testType.testExpiryDate}`);
-                    }else {
+                    } else {
                       // less than 2 months then set expiryDate 1 year after the Registration/First Use Anniversary date
                       testType.testExpiryDate = dateFns.addYears(anvDateForCompare, 1).toISOString();
                       console.log(`Setting expiryDate 1yr after AnvDate: ${testType.testExpiryDate}`);
@@ -316,7 +316,7 @@ export class TestResultsService {
 
   public isFirstTestRetestTestType(testType: any): boolean {
     const adrTestTypeIds = ["95", "41", "64", "102"];
-    return adrTestTypeIds.includes(testType.testTypeId)
+    return adrTestTypeIds.includes(testType.testTypeId);
   }
   public getMostRecentExpiryDateOnAllTestTypesByVin(vin: any) {
     let maxDate = new Date(1970, 1, 1);

--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -284,11 +284,14 @@ export class TestResultsService {
                     const regOrFirstUseDate = payload.vehicleType === VEHICLE_TYPES.HGV ? payload.regnDate : payload.firstUseDate;
                     const anvDateForCompare = regOrFirstUseDate ? dateFns.addYears(dateFns.lastDayOfMonth(regOrFirstUseDate), 1).toISOString() : undefined;
                     // If anniversaryDate is not populated in tech-records OR test date is 2 months or more before the Registration/First Use Anniversary for HGV/TRL
+                    console.log(`Current date: ${new Date()}, annv Date: ${anvDateForCompare}`);
                     if (!anvDateForCompare || dateFns.isBefore(new  Date(), dateFns.subMonths(anvDateForCompare, 2))) {
                       testType.testExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1).toISOString();
+                      console.log(`Setting expiryDate: ${testType.testExpiryDate}`);
                     } else {
                       // less than 2 months then set expiryDate 1 year after the Registration/First Use Anniversary date
                       testType.testExpiryDate = dateFns.addYears(anvDateForCompare, 1).toISOString();
+                      console.log(`Setting expiryDate as 1yr from RegDate: ${testType.testExpiryDate}`);
                     }
                   } else {
                     if (dateFns.isAfter(mostRecentExpiryDateOnAllTestTypesByVin, new Date()) && dateFns.isBefore(mostRecentExpiryDateOnAllTestTypesByVin, dateFns.addMonths(new Date(), 2))) {
@@ -312,7 +315,7 @@ export class TestResultsService {
   }
 
   public isFirstTestRetestTestType(testType: any): boolean {
-    const adrTestTypeIds = ["95", "41", "64", "102"];
+    const adrTestTypeIds = ["41", "64", "65", "66", "67", "95", "102", "103", "104"];
     return adrTestTypeIds.includes(testType.testTypeId);
   }
   public getMostRecentExpiryDateOnAllTestTypesByVin(vin: any) {

--- a/tests/resources/test-results-post.json
+++ b/tests/resources/test-results-post.json
@@ -445,8 +445,7 @@
     "testStationPNumber": "87-1369569",
     "testerEmailAddress": "dorel.popescu@dvsagov.uk",
     "euVehicleCategory": "m1",
-    "trailerId": "abcd",
-    "firstUseDate": ""
+    "trailerId": "abcd"
   },
   {
     "testerStaffId": "1",
@@ -516,8 +515,7 @@
     "testStationPNumber": "87-1369569",
     "testerEmailAddress": "dorel.popescu@dvsagov.uk",
     "euVehicleCategory": "m1",
-    "trailerId": "abcd",
-    "firstUseDate": null
+    "trailerId": "abcd"
   },
   {
     "testerStaffId": "1",

--- a/tests/resources/test-results-post.json
+++ b/tests/resources/test-results-post.json
@@ -374,7 +374,8 @@
     "vrm": "JY58FPP",
     "testStationPNumber": "87-1369569",
     "testerEmailAddress": "dorel.popescu@dvsagov.uk",
-    "euVehicleCategory": "m1"
+    "euVehicleCategory": "m1",
+    "regnDate": "2019-10-11"
   },
   {
     "testerStaffId": "1",
@@ -444,7 +445,8 @@
     "testStationPNumber": "87-1369569",
     "testerEmailAddress": "dorel.popescu@dvsagov.uk",
     "euVehicleCategory": "m1",
-    "trailerId": "abcd"
+    "trailerId": "abcd",
+    "firstUseDate": ""
   },
   {
     "testerStaffId": "1",
@@ -514,6 +516,78 @@
     "testStationPNumber": "87-1369569",
     "testerEmailAddress": "dorel.popescu@dvsagov.uk",
     "euVehicleCategory": "m1",
-    "trailerId": "abcd"
+    "trailerId": "abcd",
+    "firstUseDate": null
+  },
+  {
+    "testerStaffId": "1",
+    "testResultId": "195",
+    "testStartTimestamp": "2019-01-14T10:36:33.987Z",
+    "testEndTimestamp": "2019-01-14T10:36:33.987Z",
+    "testStatus": "submitted",
+    "noOfAxles": "2",
+    "testTypes": [
+      {
+        "prohibitionIssued": false,
+        "additionalCommentsForAbandon": "none",
+        "testTypeEndTimestamp": "2019-01-14T10:36:33.987Z",
+        "reasonForAbandoning": "none",
+        "testTypeId": "95",
+        "testTypeStartTimestamp": "2019-01-14T10:36:33.987Z",
+        "certificateNumber": "W01A00209",
+        "testTypeName": "First test",
+        "additionalNotesRecorded": "VEHICLE FRONT REGISTRATION PLATE MISSING",
+        "defects": [
+          {
+            "prohibitionIssued": false,
+            "deficiencyCategory": "major",
+            "deficiencyText": "missing.",
+            "prs": false,
+            "additionalInformation": {
+              "location": {
+                "axleNumber": null,
+                "horizontal": null,
+                "vertical": null,
+                "longitudinal": "front",
+                "rowNumber": null,
+                "lateral": null,
+                "seatNumber": null
+              },
+              "notes": "None"
+            },
+            "itemNumber": 1,
+            "deficiencyRef": "1.1.a",
+            "stdForProhibition": false,
+            "deficiencySubId": null,
+            "imDescription": "Registration Plate",
+            "deficiencyId": "a",
+            "itemDescription": "A registration plate:",
+            "imNumber": 1
+          }
+        ],
+        "name": "First test",
+        "testResult": "pass"
+      }
+    ],
+    "vehicleClass": {
+      "description": "motorbikes over 200cc or with a sidecar",
+      "code": "2"
+    },
+    "vin": "P012301230123",
+    "testStationName": "Rowe, Wunsch and Wisoky",
+    "noOfAxles": 2,
+    "vehicleType": "trl",
+    "countryOfRegistration": "united kingdom",
+    "preparerId": "ak4434",
+    "preparerName": "Durrell Vehicles Limited",
+    "vehicleConfiguration": "rigid",
+    "testStationType": "gvts",
+    "reasonForCancellation": "none",
+    "testerName": "Dorel",
+    "testStationPNumber": "87-1369569",
+    "testerEmailAddress": "dorel.popescu@dvsagov.uk",
+    "euVehicleCategory": "m1",
+    "trailerId": "abcd",
+    "firstUseDate": "2019-10-11"
   }
 ]

--- a/tests/resources/test-results-post.json
+++ b/tests/resources/test-results-post.json
@@ -375,7 +375,7 @@
     "testStationPNumber": "87-1369569",
     "testerEmailAddress": "dorel.popescu@dvsagov.uk",
     "euVehicleCategory": "m1",
-    "regnDate": "2019-10-11"
+    "regnDate": "2018-10-10"
   },
   {
     "testerStaffId": "1",
@@ -586,6 +586,6 @@
     "testerEmailAddress": "dorel.popescu@dvsagov.uk",
     "euVehicleCategory": "m1",
     "trailerId": "abcd",
-    "firstUseDate": "2019-10-11"
+    "firstUseDate": "2018-11-11"
   }
 ]

--- a/tests/resources/test-results.json
+++ b/tests/resources/test-results.json
@@ -1555,5 +1555,89 @@
     "testerEmailAddress": "dorel.popescu@dvsagov.uk",
     "euVehicleCategory": "m1",
     "deletionFlag": false
+  },
+  {
+    "testResultId": "16",
+    "testerStaffId": "1",
+    "testStartTimestamp": "2019-01-14T10:36:33.987Z",
+    "odometerReadingUnits": "kilometres",
+    "testEndTimestamp": "2019-01-14T10:36:33.987Z",
+    "testStatus": "submitted",
+    "testTypes": [
+      {
+        "prohibitionIssued": false,
+        "testCode": "ffv2",
+        "testNumber": "1",
+        "lastUpdatedAt": "2019-02-22T08:47:59.269Z",
+        "testAnniversaryDate": "2019-12-22T08:47:59.749Z",
+        "additionalCommentsForAbandon": "none",
+        "numberOfSeatbeltsFitted": 2,
+        "testTypeEndTimestamp": "2019-01-14T10:36:33.987Z",
+        "reasonForAbandoning": "none",
+        "lastSeatbeltInstallationCheckDate": "2019-01-14",
+        "createdAt": "2019-02-22T08:47:59.269Z",
+        "testTypeId": "95",
+        "testTypeStartTimestamp": "2019-01-14T10:36:33.987Z",
+        "testTypeName": "First test",
+        "seatbeltInstallationCheckDate": true,
+        "additionalNotesRecorded": "VEHICLE FRONT REGISTRATION PLATE MISSING",
+        "defects": [
+          {
+            "deficiencyCategory": "major",
+            "deficiencyText": "missing.",
+            "prs": false,
+            "additionalInformation": {
+              "location": {
+                "axleNumber": null,
+                "horizontal": null,
+                "vertical": null,
+                "longitudinal": "front",
+                "rowNumber": null,
+                "lateral": null,
+                "seatNumber": null
+              },
+              "notes": "None"
+            },
+            "itemNumber": 1,
+            "deficiencyRef": "1.1.a",
+            "stdForProhibition": false,
+            "deficiencySubId": null,
+            "imDescription": "Registration Plate",
+            "deficiencyId": "a",
+            "itemDescription": "A registration plate:",
+            "imNumber": 1
+          }
+        ],
+        "name": "First test",
+        "certificateLink": "http://dvsagov.co.uk",
+        "testTypeClassification": "Annual With Certificate",
+        "testResult": "pass",
+        "deletionFlag": false
+      }
+    ],
+    "vehicleClass": {
+      "description": "motorbikes over 200cc or with a sidecar",
+      "code": "2"
+    },
+    "vin": "P012301293847",
+    "vehicleSize": "small",
+    "testStationName": "Rowe, Wunsch and Wisoky",
+    "vehicleId": "CO79ERT",
+    "vehicleType": "hgv",
+    "countryOfRegistration": "united kingdom",
+    "preparerId": "ak4434",
+    "preparerName": "Durrell Vehicles Limited",
+    "odometerReading": 100000,
+    "vehicleConfiguration": "rigid",
+    "testStationType": "gvts",
+    "reasonForCancellation": "none",
+    "testerName": "Dorel",
+    "vrm": "CO79ERT",
+    "testStationPNumber": "87-1369569",
+    "numberOfSeats": 45,
+    "noOfAxles": 2,
+    "testerEmailAddress": "dorel.popescu@dvsagov.uk",
+    "euVehicleCategory": "n1",
+    "deletionFlag": false
   }
 ]

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -1277,7 +1277,7 @@ describe("insertTestResult", () => {
         });
     });
 
-    context("when inserting a HGV test result with firstUseDate field)", () => {
+    context("when inserting a HGV test result with firstUseDate field", () => {
         it("should throw 400", () => {
             const testResult = {...testResultsPostMock[4]};
             testResult.firstUseDate = "2019-10-11";

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -1163,4 +1163,154 @@ describe("insertTestResult", () => {
                 });
         });
     });
+
+    context("when inserting an TRL test result with firstUseDate field", () => {
+        it("should not throw error", () => {
+            const testResult = {...testResultsPostMock[6]};
+
+            MockTestResultsDAO = jest.fn().mockImplementation(() => {
+                return {
+                    createSingle: () => {
+                        return Promise.resolve(Array.of(testResultsPostMock[6]));
+                    },
+                    getTestNumber: () => {
+                        return Promise.resolve({ testNumber: "W01A00209", id: "W01", certLetter: "A", sequenceNumber: "002" });
+                    },
+                    getTestCodesAndClassificationFromTestTypes: () => {
+                        return Promise.resolve({
+                            linkedTestCode: "wde",
+                            defaultTestCode: "bde",
+                            testTypeClassification: "Annual With Certificate"
+                        });
+                    }
+                };
+            });
+
+            testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+            return testResultsService.insertTestResult(testResult)
+                .then((insertedTestResult: any) => {
+                    expect(insertedTestResult).to.not.be.eql(undefined);
+                })
+                .catch(() => {
+                    expect.fail();
+                });
+        });
+    });
+
+    context("when inserting a TRL test result with regnDate field)", () => {
+        it("should throw 400", () => {
+            const testResult = {...testResultsPostMock[5]};
+            testResult.regnDate = "2019-10-11";
+
+            MockTestResultsDAO = jest.fn().mockImplementation(() => {
+                return {
+                    createSingle: () => {
+                        return Promise.resolve(Array.of(testResultsPostMock[4]));
+                    },
+                    getTestNumber: () => {
+                        return Promise.resolve({
+                            testNumber: "W01A00209",
+                            id: "W01",
+                            certLetter: "A",
+                            sequenceNumber: "002"
+                        });
+                    },
+                    getTestCodesAndClassificationFromTestTypes: () => {
+                        return Promise.resolve({
+                            linkedTestCode: "wde",
+                            defaultTestCode: "bde",
+                            testTypeClassification: "Annual With Certificate"
+                        });
+                    }
+                };
+            });
+
+            testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+            return testResultsService.insertTestResult(testResult)
+                .then(() => {
+                    expect.fail();
+                })
+                .catch((error: { statusCode: any; body: any; }) => {
+                    expect(error).to.be.instanceOf(HTTPError);
+                    expect(error.statusCode).to.be.eql(400);
+                });
+        });
+    });
+
+    context("when inserting an HGV test result with regnDate field", () => {
+        it("should not throw error", () => {
+            const testResult = {...testResultsPostMock[4]};
+
+            MockTestResultsDAO = jest.fn().mockImplementation(() => {
+                return {
+                    createSingle: () => {
+                        return Promise.resolve(Array.of(testResultsPostMock[4]));
+                    },
+                    getTestNumber: () => {
+                        return Promise.resolve({ testNumber: "W01A00209", id: "W01", certLetter: "A", sequenceNumber: "002" });
+                    },
+                    getTestCodesAndClassificationFromTestTypes: () => {
+                        return Promise.resolve({
+                            linkedTestCode: "wde",
+                            defaultTestCode: "bde",
+                            testTypeClassification: "Annual With Certificate"
+                        });
+                    }
+                };
+            });
+
+            testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+            return testResultsService.insertTestResult(testResult)
+                .then((insertedTestResult: any) => {
+                    expect(insertedTestResult).to.not.be.eql(undefined);
+                })
+                .catch(() => {
+                    expect.fail();
+                });
+        });
+    });
+
+    context("when inserting a HGV test result with firstUseDate field)", () => {
+        it("should throw 400", () => {
+            const testResult = {...testResultsPostMock[4]};
+            testResult.firstUseDate = "2019-10-11";
+
+            MockTestResultsDAO = jest.fn().mockImplementation(() => {
+                return {
+                    createSingle: () => {
+                        return Promise.resolve(Array.of(testResultsPostMock[4]));
+                    },
+                    getTestNumber: () => {
+                        return Promise.resolve({
+                            testNumber: "W01A00209",
+                            id: "W01",
+                            certLetter: "A",
+                            sequenceNumber: "002"
+                        });
+                    },
+                    getTestCodesAndClassificationFromTestTypes: () => {
+                        return Promise.resolve({
+                            linkedTestCode: "wde",
+                            defaultTestCode: "bde",
+                            testTypeClassification: "Annual With Certificate"
+                        });
+                    }
+                };
+            });
+
+            testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+            return testResultsService.insertTestResult(testResult)
+                .then(() => {
+                    expect.fail();
+                })
+                .catch((error: { statusCode: any; body: any; }) => {
+                    expect(error).to.be.instanceOf(HTTPError);
+                    expect(error.statusCode).to.be.eql(400);
+                });
+        });
+    });
 });

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -1166,12 +1166,12 @@ describe("insertTestResult", () => {
 
     context("when inserting an TRL test result with firstUseDate field", () => {
         it("should not throw error", () => {
-            const testResult = {...testResultsPostMock[6]};
+            const testResult = {...testResultsPostMock[7]};
 
             MockTestResultsDAO = jest.fn().mockImplementation(() => {
                 return {
                     createSingle: () => {
-                        return Promise.resolve(Array.of(testResultsPostMock[6]));
+                        return Promise.resolve(Array.of(testResultsPostMock[7]));
                     },
                     getTestNumber: () => {
                         return Promise.resolve({ testNumber: "W01A00209", id: "W01", certLetter: "A", sequenceNumber: "002" });
@@ -1190,7 +1190,9 @@ describe("insertTestResult", () => {
 
             return testResultsService.insertTestResult(testResult)
                 .then((insertedTestResult: any) => {
-                    expect(insertedTestResult).to.not.be.eql(undefined);
+                    expect(insertedTestResult[0].vehicleType).to.be.eql("trl");
+                    expect(insertedTestResult[0].testResultId).to.be.eql("195");
+                    expect(insertedTestResult[0].firstUseDate).to.be.eql("2018-11-11");
                 })
                 .catch(() => {
                     expect.fail();
@@ -1265,7 +1267,9 @@ describe("insertTestResult", () => {
 
             return testResultsService.insertTestResult(testResult)
                 .then((insertedTestResult: any) => {
-                    expect(insertedTestResult).to.not.be.eql(undefined);
+                    expect(insertedTestResult[0].vehicleType).to.be.eql("hgv");
+                    expect(insertedTestResult[0].testResultId).to.be.eql("1113");
+                    expect(insertedTestResult[0].regnDate).to.be.eql("2018-10-10");
                 })
                 .catch(() => {
                     expect.fail();

--- a/tests/unit/setExpiryDateAndCertificateNumber.unitTest.ts
+++ b/tests/unit/setExpiryDateAndCertificateNumber.unitTest.ts
@@ -187,6 +187,9 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
             });
         });
 
+        /*
+         * AC-1 of CVSB-8658
+         */
         context("expiryDate for hgv vehicle type", () => {
             context("when there is a First Test Type with no existing expiryDate and testDate is 2 months or more before Registration Anniversary date.", () => {
                 it("should set the expiry date to last day of test date month + 1 year", () => {
@@ -224,6 +227,8 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
             });
         });
 
+        /* AC-4 of CVSB-8658
+         */
         context("expiryDate for hgv vehicle type", () => {
             context("when there is a First Test Type with no existing expiryDate and regnDate also not populated", () => {
                 it("should set the expiry date to last day of test date month + 1 year", () => {
@@ -260,6 +265,9 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
             });
         });
 
+        /*
+         * AC-2 of CVSB-8658
+         */
         context("expiryDate for hgv vehicle type", () => {
             context("when there is a First Test Type with no existing expiryDate and testDate is less than 2 months before Registration Anniversary date.", () => {
                 it("should set the expiry date to 1 year after the Registration Anniversary day", () => {
@@ -298,6 +306,9 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
             });
         });
 
+        /*
+         * AC-1 for TRL vehicle type of CVSB-8658
+         */
         context("expiryDate for trl vehicle type", () => {
             context("when there is a First Test Type with no existing expiryDate and testDate is 2 months or more before First Use Anniversary date.", () => {
                 it("should set the expiry date to last day of test date month + 1 year", () => {
@@ -337,6 +348,9 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
             });
         });
 
+        /*
+         * AC-5 of CVSB-8658
+         */
         context("expiryDate for trl vehicle type", () => {
             context("when there is a First Test Type with no existing expiryDate and firstUseDate also not populated", () => {
                 it("should set the expiry date to last day of test date month + 1 year", () => {
@@ -375,6 +389,9 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
             });
         });
 
+        /*
+         * AC-3 of CVSB-8658
+         */
         context("expiryDate for trl vehicle type", () => {
             context("when there is a First Test Type with no existing expiryDate and testDate is less than 2 months before First Use Anniversary date.", () => {
                 it("should set the expiry date to 1 year after the First Use Anniversary day", () => {

--- a/tests/unit/setExpiryDateAndCertificateNumber.unitTest.ts
+++ b/tests/unit/setExpiryDateAndCertificateNumber.unitTest.ts
@@ -193,7 +193,7 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
                     const hgvTestResult = testResultsMockDB[16];
                     const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
                     // Setting regnDate to a year older + 2 months
-                    testResultExpiredCertificateWithSameVin.regnDate = dateFns.subYears(dateFns.addMonths(new Date(),2), 1);
+                    testResultExpiredCertificateWithSameVin.regnDate = dateFns.subYears(dateFns.addMonths(new Date(), 2), 1);
 
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
@@ -266,7 +266,7 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
                     const hgvTestResult = testResultsMockDB[16];
                     const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
                     // not regnDate to a year older + 1 month
-                    testResultExpiredCertificateWithSameVin.regnDate = dateFns.subYears(dateFns.addMonths(new Date(),1), 1);
+                    testResultExpiredCertificateWithSameVin.regnDate = dateFns.subYears(dateFns.addMonths(new Date(), 1), 1);
 
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
@@ -288,7 +288,7 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
                     });
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
 
-                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(testResultExpiredCertificateWithSameVin.regnDate), 1).toISOString()
+                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(testResultExpiredCertificateWithSameVin.regnDate), 1).toISOString();
                     const expectedExpiryDate = dateFns.addYears(anniversaryDate, 1);
                     return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
                         .then((hgvTestResultWithExpiryDate: any) => {
@@ -306,7 +306,7 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
                     // Setting vehicleType to trl
                     testResultExpiredCertificateWithSameVin.vehicleType = "trl";
                     // Setting firstUseDate to a year older + 2 months
-                    testResultExpiredCertificateWithSameVin.firstUseDate = dateFns.subYears(dateFns.addMonths(new Date(),2), 1);
+                    testResultExpiredCertificateWithSameVin.firstUseDate = dateFns.subYears(dateFns.addMonths(new Date(), 2), 1);
 
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
@@ -383,7 +383,7 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
                     // Setting vehicleType to trl
                     testResultExpiredCertificateWithSameVin.vehicleType = "trl";
                     // not regnDate to a year older + 1 month
-                    testResultExpiredCertificateWithSameVin.firstUseDate = dateFns.subYears(dateFns.addMonths(new Date(),1), 1);
+                    testResultExpiredCertificateWithSameVin.firstUseDate = dateFns.subYears(dateFns.addMonths(new Date(), 1), 1);
 
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
@@ -405,7 +405,7 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
                     });
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
 
-                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(testResultExpiredCertificateWithSameVin.firstUseDate), 1).toISOString()
+                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(testResultExpiredCertificateWithSameVin.firstUseDate), 1).toISOString();
                     const expectedExpiryDate = dateFns.addYears(anniversaryDate, 1);
                     return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
                         .then((hgvTestResultWithExpiryDate: any) => {

--- a/tests/unit/setExpiryDateAndCertificateNumber.unitTest.ts
+++ b/tests/unit/setExpiryDateAndCertificateNumber.unitTest.ts
@@ -186,6 +186,234 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
                 });
             });
         });
+
+        context("expiryDate for hgv vehicle type", () => {
+            context("when there is a First Test Type with no existing expiryDate and testDate is 2 months or more before Registration Anniversary date.", () => {
+                it("should set the expiry date to last day of test date month + 1 year", () => {
+                    const hgvTestResult = testResultsMockDB[16];
+                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
+                    // Setting regnDate to a year older + 2 months
+                    testResultExpiredCertificateWithSameVin.regnDate = dateFns.subYears(dateFns.addMonths(new Date(),2), 1);
+
+                    MockTestResultsDAO = jest.fn().mockImplementation(() => {
+                        return {
+                            getByVin: (vin: any) => {
+                                return Promise.resolve({
+                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Count: 1,
+                                    ScannedCount: 1
+                                });
+                            },
+                            getTestCodesAndClassificationFromTestTypes: () => {
+                                return Promise.resolve({
+                                    linkedTestCode: "ffv2",
+                                    defaultTestCode: null,
+                                    testTypeClassification: "Annual With Certificate"
+                                });
+                            }
+                        };
+                    });
+                    testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+                    const expectedExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1);
+                    return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
+                        .then((hgvTestResultWithExpiryDate: any) => {
+                            expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).to.equal(expectedExpiryDate.toISOString().split("T")[0]);
+                        });
+                });
+            });
+        });
+
+        context("expiryDate for hgv vehicle type", () => {
+            context("when there is a First Test Type with no existing expiryDate and regnDate also not populated", () => {
+                it("should set the expiry date to last day of test date month + 1 year", () => {
+                    const hgvTestResult = testResultsMockDB[16];
+                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
+                    // not setting regnDate with any value
+
+                    MockTestResultsDAO = jest.fn().mockImplementation(() => {
+                        return {
+                            getByVin: (vin: any) => {
+                                return Promise.resolve({
+                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Count: 1,
+                                    ScannedCount: 1
+                                });
+                            },
+                            getTestCodesAndClassificationFromTestTypes: () => {
+                                return Promise.resolve({
+                                    linkedTestCode: "ffv2",
+                                    defaultTestCode: null,
+                                    testTypeClassification: "Annual With Certificate"
+                                });
+                            }
+                        };
+                    });
+                    testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+                    const expectedExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1);
+                    return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
+                        .then((hgvTestResultWithExpiryDate: any) => {
+                            expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).to.equal(expectedExpiryDate.toISOString().split("T")[0]);
+                        });
+                });
+            });
+        });
+
+        context("expiryDate for hgv vehicle type", () => {
+            context("when there is a First Test Type with no existing expiryDate and testDate is less than 2 months before Registration Anniversary date.", () => {
+                it("should set the expiry date to 1 year after the Registration Anniversary day", () => {
+                    const hgvTestResult = testResultsMockDB[16];
+                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
+                    // not regnDate to a year older + 1 month
+                    testResultExpiredCertificateWithSameVin.regnDate = dateFns.subYears(dateFns.addMonths(new Date(),1), 1);
+
+                    MockTestResultsDAO = jest.fn().mockImplementation(() => {
+                        return {
+                            getByVin: (vin: any) => {
+                                return Promise.resolve({
+                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Count: 1,
+                                    ScannedCount: 1
+                                });
+                            },
+                            getTestCodesAndClassificationFromTestTypes: () => {
+                                return Promise.resolve({
+                                    linkedTestCode: "ffv2",
+                                    defaultTestCode: null,
+                                    testTypeClassification: "Annual With Certificate"
+                                });
+                            }
+                        };
+                    });
+                    testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(testResultExpiredCertificateWithSameVin.regnDate), 1).toISOString()
+                    const expectedExpiryDate = dateFns.addYears(anniversaryDate, 1);
+                    return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
+                        .then((hgvTestResultWithExpiryDate: any) => {
+                            expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).to.equal(expectedExpiryDate.toISOString().split("T")[0]);
+                        });
+                });
+            });
+        });
+
+        context("expiryDate for trl vehicle type", () => {
+            context("when there is a First Test Type with no existing expiryDate and testDate is 2 months or more before First Use Anniversary date.", () => {
+                it("should set the expiry date to last day of test date month + 1 year", () => {
+                    const hgvTestResult = testResultsMockDB[16];
+                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
+                    // Setting vehicleType to trl
+                    testResultExpiredCertificateWithSameVin.vehicleType = "trl";
+                    // Setting firstUseDate to a year older + 2 months
+                    testResultExpiredCertificateWithSameVin.firstUseDate = dateFns.subYears(dateFns.addMonths(new Date(),2), 1);
+
+                    MockTestResultsDAO = jest.fn().mockImplementation(() => {
+                        return {
+                            getByVin: (vin: any) => {
+                                return Promise.resolve({
+                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Count: 1,
+                                    ScannedCount: 1
+                                });
+                            },
+                            getTestCodesAndClassificationFromTestTypes: () => {
+                                return Promise.resolve({
+                                    linkedTestCode: "ffv2",
+                                    defaultTestCode: null,
+                                    testTypeClassification: "Annual With Certificate"
+                                });
+                            }
+                        };
+                    });
+                    testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+                    const expectedExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1);
+                    return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
+                        .then((hgvTestResultWithExpiryDate: any) => {
+                            expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).to.equal(expectedExpiryDate.toISOString().split("T")[0]);
+                        });
+                });
+            });
+        });
+
+        context("expiryDate for trl vehicle type", () => {
+            context("when there is a First Test Type with no existing expiryDate and firstUseDate also not populated", () => {
+                it("should set the expiry date to last day of test date month + 1 year", () => {
+                    const hgvTestResult = testResultsMockDB[16];
+                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
+                    // not setting firstUseDate with any value
+                    // Setting vehicleType to trl
+                    testResultExpiredCertificateWithSameVin.vehicleType = "trl";
+
+                    MockTestResultsDAO = jest.fn().mockImplementation(() => {
+                        return {
+                            getByVin: (vin: any) => {
+                                return Promise.resolve({
+                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Count: 1,
+                                    ScannedCount: 1
+                                });
+                            },
+                            getTestCodesAndClassificationFromTestTypes: () => {
+                                return Promise.resolve({
+                                    linkedTestCode: "ffv2",
+                                    defaultTestCode: null,
+                                    testTypeClassification: "Annual With Certificate"
+                                });
+                            }
+                        };
+                    });
+                    testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+                    const expectedExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1);
+                    return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
+                        .then((hgvTestResultWithExpiryDate: any) => {
+                            expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).to.equal(expectedExpiryDate.toISOString().split("T")[0]);
+                        });
+                });
+            });
+        });
+
+        context("expiryDate for trl vehicle type", () => {
+            context("when there is a First Test Type with no existing expiryDate and testDate is less than 2 months before First Use Anniversary date.", () => {
+                it("should set the expiry date to 1 year after the First Use Anniversary day", () => {
+                    const hgvTestResult = testResultsMockDB[16];
+                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
+                    // Setting vehicleType to trl
+                    testResultExpiredCertificateWithSameVin.vehicleType = "trl";
+                    // not regnDate to a year older + 1 month
+                    testResultExpiredCertificateWithSameVin.firstUseDate = dateFns.subYears(dateFns.addMonths(new Date(),1), 1);
+
+                    MockTestResultsDAO = jest.fn().mockImplementation(() => {
+                        return {
+                            getByVin: (vin: any) => {
+                                return Promise.resolve({
+                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Count: 1,
+                                    ScannedCount: 1
+                                });
+                            },
+                            getTestCodesAndClassificationFromTestTypes: () => {
+                                return Promise.resolve({
+                                    linkedTestCode: "ffv2",
+                                    defaultTestCode: null,
+                                    testTypeClassification: "Annual With Certificate"
+                                });
+                            }
+                        };
+                    });
+                    testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(testResultExpiredCertificateWithSameVin.firstUseDate), 1).toISOString()
+                    const expectedExpiryDate = dateFns.addYears(anniversaryDate, 1);
+                    return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
+                        .then((hgvTestResultWithExpiryDate: any) => {
+                            expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).to.equal(expectedExpiryDate.toISOString().split("T")[0]);
+                        });
+                });
+            });
+        });
     });
 
     context("no testTypes", () => {

--- a/tests/unit/setExpiryDateAndCertificateNumber.unitTest.ts
+++ b/tests/unit/setExpiryDateAndCertificateNumber.unitTest.ts
@@ -194,15 +194,14 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
             context("when there is a First Test Type with no existing expiryDate and testDate is 2 months or more before Registration Anniversary date.", () => {
                 it("should set the expiry date to last day of test date month + 1 year", () => {
                     const hgvTestResult = testResultsMockDB[16];
-                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
                     // Setting regnDate to a year older + 2 months
-                    testResultExpiredCertificateWithSameVin.regnDate = dateFns.subYears(dateFns.addMonths(new Date(), 2), 1);
+                    hgvTestResult.regnDate = dateFns.subYears(dateFns.addMonths(new Date(), 2), 1);
 
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
                             getByVin: (vin: any) => {
                                 return Promise.resolve({
-                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Items: Array.of(hgvTestResult),
                                     Count: 1,
                                     ScannedCount: 1
                                 });
@@ -233,14 +232,13 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
             context("when there is a First Test Type with no existing expiryDate and regnDate also not populated", () => {
                 it("should set the expiry date to last day of test date month + 1 year", () => {
                     const hgvTestResult = testResultsMockDB[16];
-                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
                     // not setting regnDate with any value
 
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
                             getByVin: (vin: any) => {
                                 return Promise.resolve({
-                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Items: Array.of(hgvTestResult),
                                     Count: 1,
                                     ScannedCount: 1
                                 });
@@ -272,15 +270,14 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
             context("when there is a First Test Type with no existing expiryDate and testDate is less than 2 months before Registration Anniversary date.", () => {
                 it("should set the expiry date to 1 year after the Registration Anniversary day", () => {
                     const hgvTestResult = testResultsMockDB[16];
-                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
-                    // not regnDate to a year older + 1 month
-                    testResultExpiredCertificateWithSameVin.regnDate = dateFns.subYears(dateFns.addMonths(new Date(), 1), 1);
+                    // Setting regnDate to a year older + 1 month
+                    hgvTestResult.regnDate = dateFns.subYears(dateFns.addMonths(new Date(), 1), 1);
 
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
                             getByVin: (vin: any) => {
                                 return Promise.resolve({
-                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Items: Array.of(hgvTestResult),
                                     Count: 1,
                                     ScannedCount: 1
                                 });
@@ -296,7 +293,7 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
                     });
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
 
-                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(testResultExpiredCertificateWithSameVin.regnDate), 1).toISOString();
+                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(hgvTestResult.regnDate), 1).toISOString();
                     const expectedExpiryDate = dateFns.addYears(anniversaryDate, 1);
                     return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
                         .then((hgvTestResultWithExpiryDate: any) => {
@@ -312,18 +309,17 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
         context("expiryDate for trl vehicle type", () => {
             context("when there is a First Test Type with no existing expiryDate and testDate is 2 months or more before First Use Anniversary date.", () => {
                 it("should set the expiry date to last day of test date month + 1 year", () => {
-                    const hgvTestResult = testResultsMockDB[16];
-                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
+                    const trlTestResult = testResultsMockDB[16];
                     // Setting vehicleType to trl
-                    testResultExpiredCertificateWithSameVin.vehicleType = "trl";
+                    trlTestResult.vehicleType = "trl";
                     // Setting firstUseDate to a year older + 2 months
-                    testResultExpiredCertificateWithSameVin.firstUseDate = dateFns.subYears(dateFns.addMonths(new Date(), 2), 1);
+                    trlTestResult.firstUseDate = dateFns.subYears(dateFns.addMonths(new Date(), 2), 1);
 
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
                             getByVin: (vin: any) => {
                                 return Promise.resolve({
-                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Items: Array.of(trlTestResult),
                                     Count: 1,
                                     ScannedCount: 1
                                 });
@@ -340,7 +336,7 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
 
                     const expectedExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1);
-                    return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
+                    return testResultsService.setExpiryDateAndCertificateNumber(trlTestResult)
                         .then((hgvTestResultWithExpiryDate: any) => {
                             expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).to.equal(expectedExpiryDate.toISOString().split("T")[0]);
                         });
@@ -354,17 +350,16 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
         context("expiryDate for trl vehicle type", () => {
             context("when there is a First Test Type with no existing expiryDate and firstUseDate also not populated", () => {
                 it("should set the expiry date to last day of test date month + 1 year", () => {
-                    const hgvTestResult = testResultsMockDB[16];
-                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
+                    const trlTestResult = testResultsMockDB[16];
                     // not setting firstUseDate with any value
                     // Setting vehicleType to trl
-                    testResultExpiredCertificateWithSameVin.vehicleType = "trl";
+                    trlTestResult.vehicleType = "trl";
 
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
                             getByVin: (vin: any) => {
                                 return Promise.resolve({
-                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Items: Array.of(trlTestResult),
                                     Count: 1,
                                     ScannedCount: 1
                                 });
@@ -381,7 +376,7 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
 
                     const expectedExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1);
-                    return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
+                    return testResultsService.setExpiryDateAndCertificateNumber(trlTestResult)
                         .then((hgvTestResultWithExpiryDate: any) => {
                             expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).to.equal(expectedExpiryDate.toISOString().split("T")[0]);
                         });
@@ -395,18 +390,17 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
         context("expiryDate for trl vehicle type", () => {
             context("when there is a First Test Type with no existing expiryDate and testDate is less than 2 months before First Use Anniversary date.", () => {
                 it("should set the expiry date to 1 year after the First Use Anniversary day", () => {
-                    const hgvTestResult = testResultsMockDB[16];
-                    const testResultExpiredCertificateWithSameVin = testResultsMockDB[16];
+                    const trlTestResult = testResultsMockDB[16];
                     // Setting vehicleType to trl
-                    testResultExpiredCertificateWithSameVin.vehicleType = "trl";
+                    trlTestResult.vehicleType = "trl";
                     // not regnDate to a year older + 1 month
-                    testResultExpiredCertificateWithSameVin.firstUseDate = dateFns.subYears(dateFns.addMonths(new Date(), 1), 1);
+                    trlTestResult.firstUseDate = dateFns.subYears(dateFns.addMonths(new Date(), 1), 1);
 
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
                             getByVin: (vin: any) => {
                                 return Promise.resolve({
-                                    Items: Array.of(testResultExpiredCertificateWithSameVin),
+                                    Items: Array.of(trlTestResult),
                                     Count: 1,
                                     ScannedCount: 1
                                 });
@@ -422,9 +416,9 @@ describe("TestResultsService calling setExpiryDateAndCertificateNumber", () => {
                     });
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
 
-                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(testResultExpiredCertificateWithSameVin.firstUseDate), 1).toISOString();
+                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(trlTestResult.firstUseDate), 1).toISOString();
                     const expectedExpiryDate = dateFns.addYears(anniversaryDate, 1);
-                    return testResultsService.setExpiryDateAndCertificateNumber(hgvTestResult)
+                    return testResultsService.setExpiryDateAndCertificateNumber(trlTestResult)
                         .then((hgvTestResultWithExpiryDate: any) => {
                             expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).to.equal(expectedExpiryDate.toISOString().split("T")[0]);
                         });


### PR DESCRIPTION
Updated the logic for First Test and First test Retests types when expiryDate is not existing.
Have added the 2 missing fields which will be added as part of 8703 so that i could test the logic using unit-tests.
Please provide comments.

Testing on postman is blocked due to 8703 impl, but last 2 ACs can be tested when these fields are not populated in test-results.