### PR TITLE
CVSB-11853

### DIFF
--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -304,7 +304,7 @@ export class TestResultsService {
                     if (this.isFirstTestRetestTestType(testType) && dateFns.isAfter(new Date(), firstTestAfterAnvCompareDate)) {
                         testType.testExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1).toISOString();
                     } else if (this.isFirstTestRetestTestType(testType) && dateFns.isEqual(mostRecentExpiryDateOnAllTestTypesByVin, new Date(1970, 1, 1))) {
-                      const anvDateForCompare = regOrFirstUseDate ? dateFns.addYears(dateFns.lastDayOfMonth(regOrFirstUseDate), 1).toISOString() : undefined;
+                      const anvDateForCompare = regOrFirstUseDate ? dateFns.addYears(dateFns.endOfDay(dateFns.lastDayOfMonth(regOrFirstUseDate)), 1).toISOString() : undefined;
                       // If anniversaryDate is not populated in tech-records OR test date is 2 months or more before the Registration/First Use Anniversary for HGV/TRL
                       console.log(`Current date: ${new Date()}, annv Date: ${anvDateForCompare}`);
                       if (!anvDateForCompare || dateFns.isBefore(new  Date(), dateFns.subMonths(anvDateForCompare, 2))) {

--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -302,13 +302,13 @@ export class TestResultsService {
                     const firstTestAfterAnvCompareDate = dateFns.addYears(dateFns.startOfMonth(regOrFirstUseDate!), 1);
                     // Checks for testType = First test or First test Retest AND test date is 1 year from the month of first use or registration date
                     if (this.isFirstTestRetestTestType(testType) && dateFns.isAfter(new Date(), firstTestAfterAnvCompareDate)) {
-                        testType.testExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1).toISOString();
+                      testType.testExpiryDate = dateFns.lastDayOfMonth(dateFns.addYears(new Date(), 1)).toISOString();
                     } else if (this.isFirstTestRetestTestType(testType) && dateFns.isEqual(mostRecentExpiryDateOnAllTestTypesByVin, new Date(1970, 1, 1))) {
                       const anvDateForCompare = regOrFirstUseDate ? dateFns.addYears(dateFns.endOfDay(dateFns.lastDayOfMonth(regOrFirstUseDate)), 1).toISOString() : undefined;
                       // If anniversaryDate is not populated in tech-records OR test date is 2 months or more before the Registration/First Use Anniversary for HGV/TRL
                       console.log(`Current date: ${new Date()}, annv Date: ${anvDateForCompare}`);
                       if (!anvDateForCompare || dateFns.isBefore(new  Date(), dateFns.subMonths(anvDateForCompare, 2))) {
-                        testType.testExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1).toISOString();
+                        testType.testExpiryDate = dateFns.lastDayOfMonth(dateFns.addYears(new Date(), 1)).toISOString();
                         console.log(`Setting expiryDate: ${testType.testExpiryDate}`);
                       } else {
                         // less than 2 months then set expiryDate 1 year after the Registration/First Use Anniversary date
@@ -317,9 +317,9 @@ export class TestResultsService {
                       }
                     } else {
                       if (dateFns.isAfter(mostRecentExpiryDateOnAllTestTypesByVin, new Date()) && dateFns.isBefore(mostRecentExpiryDateOnAllTestTypesByVin, dateFns.addMonths(new Date(), 2))) {
-                        testType.testExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(mostRecentExpiryDateOnAllTestTypesByVin), 1).toISOString();
+                        testType.testExpiryDate = dateFns.lastDayOfMonth(dateFns.addYears(mostRecentExpiryDateOnAllTestTypesByVin, 1)).toISOString();
                       } else {
-                        testType.testExpiryDate = dateFns.addYears(dateFns.lastDayOfMonth(new Date()), 1).toISOString();
+                        testType.testExpiryDate = dateFns.lastDayOfMonth(dateFns.addYears(new Date(), 1)).toISOString();
                       }
                     }
                   }

--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -302,13 +302,13 @@ export class TestResultsService {
                     const firstTestAfterAnvCompareDate = dateFns.addYears(dateFns.startOfMonth(regOrFirstUseDate!), 1);
                     // Checks for testType = First test or First test Retest AND test date is 1 year from the month of first use or registration date
                     if (this.isFirstTestRetestTestType(testType) && dateFns.isAfter(new Date(), firstTestAfterAnvCompareDate)) {
-                      testType.testExpiryDate = dateFns.lastDayOfMonth(dateFns.addYears(new Date(), 1)).toISOString();
+                      testType.testExpiryDate = this.lastDayOfMonthInNextYear(new Date()).toISOString();
                     } else if (this.isFirstTestRetestTestType(testType) && dateFns.isEqual(mostRecentExpiryDateOnAllTestTypesByVin, new Date(1970, 1, 1))) {
-                      const anvDateForCompare = regOrFirstUseDate ? dateFns.addYears(dateFns.endOfDay(dateFns.lastDayOfMonth(regOrFirstUseDate)), 1).toISOString() : undefined;
+                      const anvDateForCompare = regOrFirstUseDate ? dateFns.endOfDay(this.lastDayOfMonthInNextYear(regOrFirstUseDate)).toISOString() : undefined;
                       // If anniversaryDate is not populated in tech-records OR test date is 2 months or more before the Registration/First Use Anniversary for HGV/TRL
                       console.log(`Current date: ${new Date()}, annv Date: ${anvDateForCompare}`);
                       if (!anvDateForCompare || dateFns.isBefore(new  Date(), dateFns.subMonths(anvDateForCompare, 2))) {
-                        testType.testExpiryDate = dateFns.lastDayOfMonth(dateFns.addYears(new Date(), 1)).toISOString();
+                        testType.testExpiryDate = this.lastDayOfMonthInNextYear(new Date()).toISOString();
                         console.log(`Setting expiryDate: ${testType.testExpiryDate}`);
                       } else {
                         // less than 2 months then set expiryDate 1 year after the Registration/First Use Anniversary date
@@ -317,9 +317,9 @@ export class TestResultsService {
                       }
                     } else {
                       if (dateFns.isAfter(mostRecentExpiryDateOnAllTestTypesByVin, new Date()) && dateFns.isBefore(mostRecentExpiryDateOnAllTestTypesByVin, dateFns.addMonths(new Date(), 2))) {
-                        testType.testExpiryDate = dateFns.lastDayOfMonth(dateFns.addYears(mostRecentExpiryDateOnAllTestTypesByVin, 1)).toISOString();
+                        testType.testExpiryDate = this.lastDayOfMonthInNextYear(mostRecentExpiryDateOnAllTestTypesByVin).toISOString();
                       } else {
-                        testType.testExpiryDate = dateFns.lastDayOfMonth(dateFns.addYears(new Date(), 1)).toISOString();
+                        testType.testExpiryDate = this.lastDayOfMonthInNextYear(new Date()).toISOString();
                       }
                     }
                   }
@@ -333,6 +333,10 @@ export class TestResultsService {
             throw new HTTPError(500, MESSAGES.INTERNAL_SERVER_ERROR);
           });
     }
+  }
+
+  private lastDayOfMonthInNextYear(inputDate: Date): Date {
+    return dateFns.lastDayOfMonth(dateFns.addYears(inputDate, 1));
   }
 
   public isFirstTestRetestTestType(testType: any): boolean {

--- a/tests/unit/generateExpiryDate.unitTest.ts
+++ b/tests/unit/generateExpiryDate.unitTest.ts
@@ -292,8 +292,8 @@ describe("TestResultsService calling generateExpiryDate", () => {
                     });
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
 
-                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(hgvTestResult.regnDate), 1).toISOString();
-                    const expectedExpiryDate = dateFns.addYears(anniversaryDate, 1);
+                    const anniversaryDate = dateFns.addYears(hgvTestResult.regnDate, 1).toISOString();
+                    const expectedExpiryDate = dateFns.setHours(dateFns.lastDayOfMonth(dateFns.addYears(anniversaryDate, 1)), 12);
                     return testResultsService.generateExpiryDate(hgvTestResult)
                         .then((hgvTestResultWithExpiryDate: any) => {
                             expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).toEqual(expectedExpiryDate.toISOString().split("T")[0]);
@@ -415,8 +415,8 @@ describe("TestResultsService calling generateExpiryDate", () => {
                     });
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
 
-                    const anniversaryDate = dateFns.addYears(dateFns.lastDayOfMonth(trlTestResult.firstUseDate), 1).toISOString();
-                    const expectedExpiryDate = dateFns.addYears(anniversaryDate, 1);
+                    const anniversaryDate = dateFns.addYears(trlTestResult.firstUseDate, 1).toISOString();
+                    const expectedExpiryDate = dateFns.setHours(dateFns.lastDayOfMonth(dateFns.addYears(anniversaryDate, 1)), 12);
                     return testResultsService.generateExpiryDate(trlTestResult)
                         .then((hgvTestResultWithExpiryDate: any) => {
                             expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).toEqual(expectedExpiryDate.toISOString().split("T")[0]);


### PR DESCRIPTION
Expiry Date calculations on last day of month fail due to "start of day" issue. No tests, as tests were already correctly covering the issue but pass when not last day of the month.

Issue actually happens at line 310, when the current datetime is checked to see if it is before the datetime derived from regOrFirstUseDate, which is just a date so the time defaults to the start of that day. By forcing the derived datetime  to be the end of the day, all calculations proceed as expected.