### PR TITLE
CVSB-13903 vehicleClass mandatory only for motorcycles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19043,9 +19043,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "unbzip2-stream": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "tslint": "^5.20.0",
     "tslint-jsdoc-rules": "^0.2.0",
     "tslint-no-unused-expression-chai": "^0.1.4",
-    "typescript": "^3.6.4"
+    "typescript": "^3.8.3"
   },
   "dependencies": {
     "aws-sdk": "^2.645.0",

--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -11,12 +11,7 @@ export enum ERRORS {
     NoCertificateNumberOnTir = "Certificate number not present on TIR test type",
     NoExpiryDate = "Expiry date not present on ADR test type",
     IncorrectTestStatus = '"testStatus" should be one of ["submitted", "cancelled"]',
-    NoDeficiencyCategory = "/location/deficiencyText/stdForProhibition are null for a defect with deficiency category other than advisory",
     PayloadCannotBeEmpty = "Payload cannot be empty",
-    FuelTypeInvalid = "\"fuelType\" must be one of [diesel, gas-cng, gas-lng, gas-lpg, petrol, fuel cell, full electric, null]",
-    ModTypeDescriptionInvalid = "\"description\" must be one of [particulate trap, modification or change of engine, gas engine]",
-    EmissionStandardInvalid= "\"emissionStandard\" must be one of [0.10 g/kWh Euro 3 PM, 0.03 g/kWh Euro IV PM, Euro 3, Euro 4, Euro 6, Euro VI, Full Electric, null]",
-    ModTypeCodeInvalid = "\"code\" must be one of [p, m, g]",
     NoLECExpiryDate = "Expiry Date not present on LEC test type",
     NoModificationType = "Modification type not present on LEC test type",
     NoEmissionStandard = "Emission standard not present on LEC test type",
@@ -26,9 +21,20 @@ export enum ERRORS {
     EuVehicleCategoryMandatory = "\"euVehicleCategory\" is mandatory",
     OdometerReadingMandatory = "\"odometerReading\" is mandatory",
     OdometerReadingUnitsMandatory = "\"odometerReadingUnits\" is mandatory",
+}
+
+export enum TESTING_ERRORS {
+    NoDeficiencyCategory = "/location/deficiencyText/stdForProhibition are null for a defect with deficiency category other than advisory",
+    FuelTypeInvalid = "\"fuelType\" must be one of [diesel, gas-cng, gas-lng, gas-lpg, petrol, fuel cell, full electric, null]",
+    ModTypeDescriptionInvalid = "\"description\" must be one of [particulate trap, modification or change of engine, gas engine]",
+    EmissionStandardInvalid= "\"emissionStandard\" must be one of [0.10 g/kWh Euro 3 PM, 0.03 g/kWh Euro IV PM, Euro 3, Euro 4, Euro 6, Euro VI, Full Electric, null]",
+    ModTypeCodeInvalid = "\"code\" must be one of [p, m, g]",
     VehicleSubclassIsNotAllowed = "\"vehicleSubclass\" is not allowed",
     VehicleSubclassIsRequired = "\"vehicleSubclass\" is required",
-    EuVehicleCategoryMustBeOneOf = "\"euVehicleCategory\" must be one of [m1, null]"
+    EuVehicleCategoryMustBeOneOf = "\"euVehicleCategory\" must be one of [m1, null]",
+    VehicleClassIsRequired = "\"vehicleClass\" is required",
+    VehicleClassCodeIsInvalid = "\"code\" must be one of [1, 2, 3, n, s, t, l, v, 4, 5, 7, p, u]",
+    VehicleClassInvalid = "\"vehicleClass\" must be an object",
 }
 
 export enum HTTPRESPONSE {

--- a/src/models/CommonSchema.ts
+++ b/src/models/CommonSchema.ts
@@ -62,7 +62,7 @@ export const testResultsCommonSchema = {
     testEndTimestamp: Joi.date().iso().required(),
     testStatus: Joi.any().only(["submitted", "cancelled"]).required(),
     vehicleClass: Joi.object().keys({
-        code: Joi.any().only(["1", "2", "3", "n", "s", "t", "l", "v", "4", "5", "7", "p", "u"]).required(),
+        code: Joi.any().only(["1", "2", "3", "n", "s", "t", "l", "v", "4", "5", "7", "p", "u"]).allow(null),
         description: Joi.any().only([
             "motorbikes up to 200cc",
             "motorbikes over 200cc or with a sidecar",
@@ -76,9 +76,9 @@ export const testResultsCommonSchema = {
             "MOT class 5",
             "MOT class 7",
             "PSV of unknown or unspecified size",
-            "Not Known"])
-            .required()
-    }).required(),
+            "Not Known"
+        ]).allow(null)
+    }).allow(null),
     vehicleType: Joi.any().only(["psv", "hgv", "trl", "car", "lgv", "motorcycle"]).required(),
     noOfAxles: Joi.number().max(99).required(),
     preparerId: Joi.string().required().allow(""),

--- a/src/models/ITestResultPayload.ts
+++ b/src/models/ITestResultPayload.ts
@@ -1,7 +1,7 @@
 export interface ITestResultPayload {
     systemNumber: string;
-    vehicleClass: any;
-    vehicleSubclass: any;
+    vehicleClass?: any | null;
+    vehicleSubclass?: any;
     numberOfWheelsDriven: any;
     testStatus: string;
     testTypes: any[];

--- a/src/models/TestResultsSchemaMotorcycleSubmitted.ts
+++ b/src/models/TestResultsSchemaMotorcycleSubmitted.ts
@@ -2,7 +2,25 @@ import * as Joi from "joi";
 import {testResultsCommonSchemaSpecialistTestsSubmitted} from "./SpecialistTestsCommonSchemaSubmitted";
 
 const testResultsSchema = Joi.object().keys({
-    ...testResultsCommonSchemaSpecialistTestsSubmitted
+    ...testResultsCommonSchemaSpecialistTestsSubmitted,
+    vehicleClass: Joi.object().keys({
+        code: Joi.any().only(["1", "2", "3", "n", "s", "t", "l", "v", "4", "5", "7", "p", "u"]).required(),
+        description: Joi.any().only([
+            "motorbikes up to 200cc",
+            "motorbikes over 200cc or with a sidecar",
+            "3 wheelers",
+            "not applicable",
+            "small psv (ie: less than or equal to 22 seats)",
+            "trailer",
+            "large psv(ie: greater than 23 seats)",
+            "heavy goods vehicle",
+            "MOT class 4",
+            "MOT class 5",
+            "MOT class 7",
+            "PSV of unknown or unspecified size",
+            "Not Known"
+        ])
+    }).required(),
 });
 
 export default testResultsSchema;

--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -195,7 +195,7 @@ export class TestResultsService {
 
     payload = this.setCreatedAtAndLastUpdatedAtDates(payload);
     return this.getTestTypesWithTestCodesAndClassification(payload.testTypes, payload.vehicleType, payload.vehicleSize, payload.vehicleConfiguration,
-        payload.noOfAxles, payload.euVehicleCategory, payload.vehicleClass.code, payload.vehicleSubclass ? payload.vehicleSubclass[0] : undefined, payload.numberOfWheelsDriven)
+        payload.noOfAxles, payload.euVehicleCategory, payload?.vehicleClass?.code, payload?.vehicleSubclass?.[0], payload.numberOfWheelsDriven)
         .then((testTypesWithTestCodesAndClassification) => {
           payload.testTypes = testTypesWithTestCodesAndClassification;
         })


### PR DESCRIPTION
Improvement changes related to https://jira.dvsacloud.uk/browse/CVSB-13903

The ticket is covering the iteration on Test results API specs v27, to cover the optionality of the vehicleClass attribute for vehicles that are not motorcycle, due to the specialist testing. For motorcycles. the attribute remains mandatory as it is needed to derive the test code.