### PR TITLE
Feature/cvsb 15456 - Do not throw 404 is no visit is found for test-result

### DIFF
--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -254,7 +254,9 @@ export class TestResultsService {
         }
       }
     } catch (err) {
-      return Promise.reject({statusCode: err.statusCode, body: `Activities microservice error: ${err.body}`});
+      if (err.statusCode !== 404) {
+        return Promise.reject({statusCode: err.statusCode, body: `Activities microservice error: ${err.body}`});
+      }
     }
   }
 


### PR DESCRIPTION
https://jira.dvsacloud.uk/browse/CVSB-15456

This ticket is required because, there is no concept of creating a visit on VTM, hence test records newly entered on VTM do not have a visit, therefore the backend cannot ensure that the test time stamps are within the timeframes of the visit (since the visit doesnt exist)

Therefore, if a test result does not have a visit, the validation does not apply.