### PR TITLE
Expiry dates appearing 1 day more than expected in ATF/RTK/TEST HISTORY

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4723,21 +4723,23 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
+      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.3.tgz",
-      "integrity": "sha512-sHEsvEzjqN+zLbqP+8OXTipc10yH1QLR+hnr5uw29gi9AhCAAAdri8ClNV7iMdrJrIzXIQtlkPvq8tJGhj3QJQ==",
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
+      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
       "requires": {
         "@types/node": "*",
+        "@types/qs": "*",
         "@types/range-parser": "*"
       }
     },
@@ -4833,10 +4835,19 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/moment-timezone": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.13.tgz",
+      "integrity": "sha512-SWk1qM8DRssS5YR9L4eEX7WUhK/wc96aIr4nMa6p0kTk9YhGGOJjECVhIdPEj13fvJw72Xun69gScXSZ/UmcPg==",
+      "dev": true,
+      "requires": {
+        "moment": ">=2.14.0"
+      }
+    },
     "@types/mysql": {
-      "version": "2.15.9",
-      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.9.tgz",
-      "integrity": "sha512-rB3w3/YEV11oIoL56iP4OPt6uLkcuu6oIqbUy8T2bSm/ZUYN0fvyyzzrZBDNYL//zRStdmSsUPZDtHXjdR1hTA==",
+      "version": "2.15.10",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.10.tgz",
+      "integrity": "sha512-mx8HnU+ob01hT3f4GDW8NSoUqID1CgRfiPh/CgeDgdwvG0DsQtZsPdOXH9LHos/pKv2qkZAA4/ospo0+QoOfUQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -4865,6 +4876,11 @@
       "version": "1.11.5",
       "resolved": "https://registry.npmjs.org/@types/pg-types/-/pg-types-1.11.5.tgz",
       "integrity": "sha512-L8ogeT6vDzT1vxlW3KITTCt+BVXXVkLXfZ/XNm6UqbcJgxf+KPO7yjWx7dQQE8RW07KopL10x2gNMs41+IkMGQ=="
+    },
+    "@types/qs": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.2.tgz",
+      "integrity": "sha512-a9bDi4Z3zCZf4Lv1X/vwnvbbDYSNz59h3i3KdyuYYN+YrLjSeJD0dnphdULDfySvUv6Exy/O0K6wX/kQpnPQ+A=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -9229,7 +9245,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -15169,10 +15185,17 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
+      "version": "2.25.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
+      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg=="
+    },
+    "moment-timezone": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
+      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "ms": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/joi": "^14.3.3",
     "@types/lambda-tester": "^3.5.1",
     "@types/lodash": "^4.14.144",
+    "@types/moment-timezone": "^0.5.13",
     "@types/node": "^12.12.0",
     "@types/request": "^2.48.1",
     "@types/sinon": "^7.0.13",
@@ -74,8 +75,9 @@
   "dependencies": {
     "aws-sdk": "^2.645.0",
     "aws-xray-sdk": "^2.5.0",
-    "date-fns": "^1.30.1",
     "joi": "^14.3.1",
+    "moment": "^2.25.3",
+    "moment-timezone": "^0.5.28",
     "lodash": "^4.17.15",
     "node-yaml": "^3.2.0",
     "path-parser": "^4.2.0",

--- a/src/functions/getTestResultsBySystemNumber.ts
+++ b/src/functions/getTestResultsBySystemNumber.ts
@@ -1,9 +1,9 @@
 import {TestResultsDAO} from "../models/TestResultsDAO";
 import {TestResultsService} from "../services/TestResultsService";
 import {HTTPResponse} from "../models/HTTPResponse";
-import * as dateFns from "date-fns";
 import {MESSAGES, TEST_VERSION} from "../assets/Enums";
 import {ISubSeg} from "../models/ISubSeg";
+import moment from "moment";
 /* workaround AWSXRay.captureAWS(...) call obscures types provided by the AWS sdk.
 https://github.com/aws/aws-xray-sdk-node/issues/14
 */
@@ -35,8 +35,8 @@ export const getTestResultsBySystemNumber = async (event: {
     let testResultId;
     let testStatus = "submitted";
     let testVersion = TEST_VERSION.CURRENT;
-    let toDateTime = dateFns.endOfToday();
-    let fromDateTime = dateFns.subYears(toDateTime, 2);
+    let toDateTime = moment().endOf("day").toDate();
+    let fromDateTime = moment(toDateTime).subtract(2, "years").toDate();
 
     try {
         if (event.queryStringParameters) {

--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -226,8 +226,9 @@ export class TestResultsService {
   }
 
   public async checkTestTypeStartAndEndTimestamp(oldTestResult: ITestResult, newTestResult: ITestResult) {
+    moment.tz.setDefault("UTC");
     const params = {
-      fromStartTime: dateFns.startOfDay(oldTestResult.testStartTimestamp),
+      fromStartTime: moment(oldTestResult.testStartTimestamp).startOf("day").toDate(),
       toStartTime: oldTestResult.testStartTimestamp,
       activityType: "visit",
       testStationPNumber: oldTestResult.testStationPNumber,
@@ -240,19 +241,19 @@ export class TestResultsService {
       }
       const activity = activities[0];
       for (const testType of newTestResult.testTypes) {
-        if (dateFns.isAfter(testType.testTypeStartTimestamp, activity.endTime) || dateFns.isBefore(testType.testTypeStartTimestamp, activity.startTime)) {
+        if (moment(testType.testTypeStartTimestamp).isAfter(activity.endTime) || moment(testType.testTypeStartTimestamp).isBefore(activity.startTime)) {
           return Promise.reject({
             statusCode: 400,
             body: `The testTypeStartTimestamp must be within the visit, between ${activity.startTime} and ${activity.endTime}`
           });
         }
-        if (dateFns.isAfter(testType.testTypeEndTimestamp, activity.endTime) || dateFns.isBefore(testType.testTypeEndTimestamp, activity.startTime)) {
+        if (moment(testType.testTypeEndTimestamp).isAfter(activity.endTime) || moment(testType.testTypeEndTimestamp).isBefore(activity.startTime)) {
           return Promise.reject({
             statusCode: 400,
             body: `The testTypeEndTimestamp must be within the visit, between ${activity.startTime} and ${activity.endTime}`
           });
         }
-        if (dateFns.isAfter(testType.testTypeStartTimestamp, testType.testTypeEndTimestamp)) {
+        if (moment(testType.testTypeStartTimestamp).isAfter(testType.testTypeEndTimestamp)) {
           return Promise.reject({statusCode: 400, body: ERRORS.StartTimeBeforeEndTime});
         }
       }

--- a/src/utils/GetTestResults.ts
+++ b/src/utils/GetTestResults.ts
@@ -1,7 +1,7 @@
-import * as dateFns from "date-fns";
 import {isDate, isFinite} from "lodash";
 import {TEST_VERSION} from "../assets/Enums";
 import {ITestResult} from "../models/ITestResult";
+import moment from "moment";
 
 
 export class GetTestResults {
@@ -18,7 +18,7 @@ export class GetTestResults {
   public static filterTestResultByDate(testResults: any, fromDateTime: string | number | Date, toDateTime: string | number | Date) {
 
     return testResults.filter((testResult: { testStartTimestamp: string | number | Date; testEndTimestamp: string | number | Date; }) => {
-      return dateFns.isAfter(testResult.testStartTimestamp, fromDateTime) && dateFns.isBefore(testResult.testEndTimestamp, toDateTime);
+      return moment(testResult.testStartTimestamp).isAfter(fromDateTime) && moment(testResult.testEndTimestamp).isBefore(toDateTime);
     });
   }
 

--- a/tests/unit/generateCertificateNumber.unitTest.ts
+++ b/tests/unit/generateCertificateNumber.unitTest.ts
@@ -1,7 +1,6 @@
 import { TestResultsService } from "../../src/services/TestResultsService";
 import fs from "fs";
 import path from "path";
-import * as dateFns from "date-fns";
 import {cloneDeep} from "lodash";
 
 describe("TestResultsService calling generateExpiryDate", () => {

--- a/tests/unit/getTestResultsBySystemNumberFunction.unitTest.ts
+++ b/tests/unit/getTestResultsBySystemNumberFunction.unitTest.ts
@@ -1,9 +1,9 @@
 import {getTestResultsBySystemNumber} from "../../src/functions/getTestResultsBySystemNumber";
 import {TestResultsService} from "../../src/services/TestResultsService";
 import {HTTPResponse} from "../../src/models/HTTPResponse";
-import * as dateFns from "date-fns";
 import {MESSAGES} from "../../src/assets/Enums";
 import {HTTPError} from "../../src/models/HTTPError";
+import moment from "moment";
 
 describe("getTestResultsBySystemNumber Function", () => {
   const minimalEvent =  {
@@ -20,8 +20,8 @@ describe("getTestResultsBySystemNumber Function", () => {
         systemNumber: 1,
         testVersion: "current",
         testStatus: "submitted",
-        toDateTime: dateFns.endOfToday(),
-        fromDateTime: dateFns.subYears(dateFns.endOfToday(), 2)
+        toDateTime: moment().endOf("day").toDate(),
+        fromDateTime: moment().subtract(2, "years").endOf("day").toDate()
       };
 
       expect.assertions(4);
@@ -96,7 +96,7 @@ describe("getTestResultsBySystemNumber Function", () => {
           testVersion: "current",
           testStatus: "submitted",
           toDateTime: new Date("01-01-2010"),
-          fromDateTime: dateFns.subYears(dateFns.endOfToday(), 2)
+          fromDateTime: moment().subtract(2, "years").endOf("day").toDate()
         };
 
         expect.assertions(4);
@@ -124,7 +124,7 @@ describe("getTestResultsBySystemNumber Function", () => {
           systemNumber: 1,
           testVersion: "current",
           testStatus: "submitted",
-          toDateTime: dateFns.endOfToday(),
+          toDateTime: moment().endOf("day").toDate(),
           fromDateTime: new Date("01-01-2010")
         };
 
@@ -153,8 +153,8 @@ describe("getTestResultsBySystemNumber Function", () => {
           systemNumber: 1,
           testVersion: "current",
           testStatus: "cheese",
-          toDateTime: dateFns.endOfToday(),
-          fromDateTime: dateFns.subYears(dateFns.endOfToday(), 2)
+          toDateTime: moment().endOf("day").toDate(),
+          fromDateTime: moment().subtract(2, "years").endOf("day").toDate()
         };
 
         expect.assertions(4);
@@ -183,8 +183,8 @@ describe("getTestResultsBySystemNumber Function", () => {
           systemNumber: 1,
           testVersion: "archived",
           testStatus: "submitted",
-          toDateTime: dateFns.endOfToday(),
-          fromDateTime: dateFns.subYears(dateFns.endOfToday(), 2)
+          toDateTime: moment().endOf("day").toDate(),
+          fromDateTime: moment().subtract(2, "years").endOf("day").toDate()
         };
 
         expect.assertions(4);


### PR DESCRIPTION
Substituted date-fns with moment.js and fixed bug https://jira.dvsacloud.uk/browse/CVSB-14539. 
This effectively sets expiryDates at the beginning of the UTC day and can be displayed in both, UTC and British timezones correctly.
This change will require a change on the expiryDates already generated as T23:59:59.999Z