### PR TITLE
Feature/cvsb 14406 - archive test-types

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -44,16 +44,6 @@ functions:
     handler: src/handler.handler
     events:
       - http:
-          path: test-results
-          method: post
-      - http:
-          path: test-results/{systemNumber}
-          method: put
-          request:
-            parameters:
-              paths:
-                systemNumber: true
-      - http:
           path: test-results/{systemNumber}
           method: get
           request:
@@ -70,7 +60,32 @@ functions:
       - http:
           path: test-results/getTestResultsByTesterStaffId
           method: get
-
+  archiveTestResults:
+    handler: src/handler.handler
+    events:
+      - http:
+          path: test-results/archive/{testResultId}
+          method: put
+          request:
+            parameters:
+              paths:
+                testResultId: true
+  updateTestResults:
+    handler: src/handler.handler
+    events:
+      - http:
+          path: test-results/{testResultId}
+          method: put
+          request:
+            parameters:
+              paths:
+                testResultId: true
+  postTestResults:
+    handler: src/handler.handler
+    events:
+      - http:
+          path: test-results
+          method: post
 
 resources:
   Resources:

--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -23,6 +23,8 @@ export enum ERRORS {
     StartTimeBeforeEndTime = "testTypeStartTimestamp must be before testTypeEndTimestamp",
     OdometerReadingMandatory = "\"odometerReading\" is mandatory",
     OdometerReadingUnitsMandatory = "\"odometerReadingUnits\" is mandatory",
+    NoTestTypesToArchive = "There are no test types to archive",
+    TestTypeToArchiveNotFound = "The test type you want to archive does not exists on this test-result"
 }
 
 export enum TESTING_ERRORS {

--- a/src/config/config.yml
+++ b/src/config/config.yml
@@ -17,8 +17,13 @@ functions:
 - updateTestResults:
     method: PUT
     path: /test-results/{+proxy}
-    proxy: :systemNumber
+    proxy: :testResultId
     function: updateTestResults
+- archiveTestResults:
+    method: PUT
+    path: /test-results/archive/{+proxy}
+    proxy: :testResultId
+    function: archiveTestResults
 dynamodb:
   local:
     params:

--- a/src/functions/archiveTestResults.ts
+++ b/src/functions/archiveTestResults.ts
@@ -1,0 +1,75 @@
+import {TestResultsDAO} from "../models/TestResultsDAO";
+import {TestResultsService} from "../services/TestResultsService";
+import {HTTPResponse} from "../models/HTTPResponse";
+import {MESSAGES} from "../assets/Enums";
+import {ISubSeg} from "../models/ISubSeg";
+import {formatErrorMessage} from "../utils/formatErrorMessage";
+/* workaround AWSXRay.captureAWS(...) call obscures types provided by the AWS sdk.
+https://github.com/aws/aws-xray-sdk-node/issues/14
+*/
+/* tslint:disable */
+let AWS: any;
+if (process.env._X_AMZN_TRACE_ID) {
+  /* tslint:disable */
+  AWS = require("aws-xray-sdk");
+} else {
+  console.log("Serverless Offline detected; skipping AWS X-Ray setup");
+}
+/* tslint:enable */
+
+export const archiveTestResults = async (event: { pathParameters: { testResultId: any; }; body: any; }) => {
+  let subseg: ISubSeg | null = null;
+  if (process.env._X_AMZN_TRACE_ID) {
+    const segment = AWS.getSegment();
+    AWS.capturePromise();
+    if (segment) {
+      subseg = segment.addNewSubsegment("archiveTestResults");
+    }
+  }
+  const testResultsDAO = new TestResultsDAO();
+  const testResultsService = new TestResultsService(testResultsDAO);
+
+  const testResultId = event.pathParameters.testResultId;
+  const testResult = event.body.testResult;
+  const msUserDetails = event.body.msUserDetails;
+
+  try {
+    if (!testResult) {
+      const errorMessage = MESSAGES.BAD_REQUEST + " test-result object not provided";
+      if (subseg) {
+        subseg.addError(errorMessage);
+      }
+      return Promise.resolve(new HTTPResponse(400, formatErrorMessage(errorMessage)));
+    }
+    if (!testResult.vin) {
+      const errorMessage = MESSAGES.BAD_REQUEST + " VIN not provided";
+      if (subseg) {
+        subseg.addError(errorMessage);
+      }
+      return Promise.resolve(new HTTPResponse(400, formatErrorMessage(errorMessage)));
+    }
+    if (!msUserDetails || !msUserDetails.msUser || !msUserDetails.msOid) {
+      const errorMessage = MESSAGES.BAD_REQUEST + " msUserDetails not provided";
+      if (subseg) {
+        subseg.addError(errorMessage);
+      }
+      return Promise.resolve(new HTTPResponse(400, formatErrorMessage(errorMessage)));
+    }
+
+    return testResultsService.archiveTestResult(testResultId, testResult, msUserDetails)
+      .then((data) => {
+        return new HTTPResponse(200, data);
+      })
+      .catch((error) => {
+        console.log("Error in archiveTestResults > archiveTestResults: ", error);
+        if (subseg) {
+          subseg.addError(error.body);
+        }
+        return new HTTPResponse(error.statusCode, error.body);
+      });
+  } finally {
+    if (subseg) {
+      subseg.close();
+    }
+  }
+};

--- a/src/models/CommonSchema.ts
+++ b/src/models/CommonSchema.ts
@@ -87,7 +87,7 @@ export const testResultsCommonSchema = Joi.object().keys({
     regnDate: Joi.string().allow("", null),
     firstUseDate: Joi.string().allow("", null),
     euVehicleCategory: Joi.any().only(["m1", "m2", "m3", "n1", "n2", "n3", "o1", "o2", "o3", "o4", "l1e-a", "l1e", "l2e", "l3e", "l4e", "l5e", "l6e", "l7e"]).required().allow(null),
-    reasonForCreation: Joi.string().max(100).optional(),
+    reasonForCreation: Joi.string().max(500).optional(),
     createdAt: Joi.string().optional().allow(null),
     createdByName: Joi.string().optional(),
     createdById: Joi.string().optional(),

--- a/src/models/ITestResult.ts
+++ b/src/models/ITestResult.ts
@@ -70,6 +70,7 @@ export interface TestType {
   certificateNumber?: string | null;
   testExpiryDate?: string | Date | null; // Sent form FE only for LEC tests. For the rest of the test types it is not sent from FE, and calculated in the BE.
   deletionFlag?: boolean | null; // Not sent from FE, calculated in the BE.
+  statusUpdatedFlag?: boolean | null; // Sent from FE when a testType is updated/archived
 
   // Used only for LEC tests.
   modType?: ModType | null;

--- a/src/models/TestResultsDAO.ts
+++ b/src/models/TestResultsDAO.ts
@@ -49,6 +49,22 @@ export class TestResultsDAO {
     return TestResultsDAO.docClient.query(params).promise();
   }
 
+  public getByTestResultId(testResultId: string, vin: string) {
+    const params = {
+      TableName: this.tableName,
+      KeyConditionExpression: "#vin = :vin and #testResultId = :testResultId",
+      ExpressionAttributeNames: {
+        "#vin": "vin",
+        "#testResultId": "testResultId"
+      },
+      ExpressionAttributeValues: {
+        ":vin": vin,
+        ":testResultId": testResultId
+      }
+    };
+    return TestResultsDAO.docClient.query(params).promise();
+  }
+
   public getByTesterStaffId(testerStaffId: any) {
     const params = {
       TableName: this.tableName,

--- a/src/models/test-types/testTypesSchemaPut.ts
+++ b/src/models/test-types/testTypesSchemaPut.ts
@@ -44,7 +44,8 @@ export const testTypesCommonSchema = Joi.object().keys({
   lastUpdatedAt: Joi.string().optional(),
   certificateLink: Joi.string().optional(),
   testTypeClassification: Joi.string().required(),
-  deletionFlag: Joi.boolean().optional()
+  deletionFlag: Joi.boolean().optional(),
+  statusUpdatedFlag: Joi.boolean().optional().allow(null)
 }).required();
 
 export const testTypesSchemaGroup1 = testTypesCommonSchema.keys({

--- a/src/models/test-types/testTypesSchemaSpecialistTestsPut.ts
+++ b/src/models/test-types/testTypesSchemaSpecialistTestsPut.ts
@@ -25,7 +25,8 @@ export const testTypesCommonSchemaSpecialistTests = Joi.object().keys({
   createdAt: Joi.string().optional(),
   lastUpdatedAt: Joi.string().optional(),
   certificateLink: Joi.string().optional(),
-  testTypeClassification: Joi.string().required()
+  testTypeClassification: Joi.string().required(),
+  statusUpdatedFlag: Joi.boolean().optional().allow(null)
 }).required();
 
 export const testTypesSchemaSpecTestGroup1 = testTypesCommonSchemaSpecialistTests.keys({

--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -154,21 +154,8 @@ export class TestResultsService {
     return testResults;
   }
 
-  public mapErrorMessage(validation: ValidationResult<any> | any ) {
-    return validation.error.details.map((detail: { message: string; }) => {
-      return detail.message;
-    });
-  }
-
-  public manageDefectsArray(testResult: ITestResult) {
-    testResult.testTypes.forEach((testType: TestType) => {
-      if (SPECIALIST_TEST_TYPE_IDS.includes(testType.testTypeId)) {
-        testType.defects = [];
-      }
-    });
-  }
-
-  public updateTestResult(systemNumber: string, payload: ITestResult, msUserDetails: IMsUserDetails) {
+  public updateTestResult(testResultId: string, payload: ITestResult, msUserDetails: IMsUserDetails) {
+    const {vin} = payload;
     this.removeNonEditableAttributes(payload);
     let validationSchema = this.getValidationSchema(payload.vehicleType, payload.testStatus);
     const testTypesValidationErrors = this.validateTestTypes(payload);
@@ -180,6 +167,7 @@ export class TestResultsService {
     delete payload.testTypes;
     validationSchema = validationSchema!.keys({
       countryOfRegistration: Joi.string().valid(COUNTRY_OF_REGISTRATION).required(),
+      reasonForCreation: Joi.string().max(500).required(),
       testTypes: Joi.any().forbidden()
     });
     validationSchema = validationSchema.optionalKeys(["testEndTimestamp", "systemNumber", "vin"]);
@@ -192,11 +180,11 @@ export class TestResultsService {
         }));
     }
     payload.testTypes = testTypes;
-    return this.testResultsDAO.getBySystemNumber(systemNumber)
+    return this.testResultsDAO.getByTestResultId(testResultId, vin)
         .then(async (result) => {
           const response: ITestResultData = {Count: result.Count, Items: result.Items};
           const testResults = this.checkTestResults(response);
-          const oldTestResult = this.getTestResultToArchive(testResults, payload.testResultId);
+          const oldTestResult = this.getTestResultToArchive(testResults);
           oldTestResult.testVersion = TEST_VERSION.ARCHIVED;
           const newTestResult: ITestResult = cloneDeep(oldTestResult);
           newTestResult.testVersion = TEST_VERSION.CURRENT;
@@ -211,12 +199,7 @@ export class TestResultsService {
           await this.checkTestTypeStartAndEndTimestamp(oldTestResult, newTestResult);
           this.manageDefectsArray(newTestResult);
           this.setAuditDetails(newTestResult, oldTestResult, msUserDetails);
-          if (!newTestResult.testHistory) {
-            newTestResult.testHistory = [oldTestResult];
-          } else {
-            delete oldTestResult.testHistory;
-            newTestResult.testHistory.push(oldTestResult);
-          }
+          this.manageTestHistoryArray(newTestResult, oldTestResult);
           return this.testResultsDAO.updateTestResult(newTestResult)
               .then((data) => {
                 return newTestResult;
@@ -226,6 +209,83 @@ export class TestResultsService {
         }).catch((error) => {
           throw new HTTPError(error.statusCode, error.body);
         });
+  }
+
+  public archiveTestResult(testResultId: string, payload: ITestResult, msUserDetails: IMsUserDetails) {
+    return this.testResultsDAO.getByTestResultId(testResultId, payload.vin)
+      .then(async (result) => {
+        const response: ITestResultData = {Count: result.Count, Items: result.Items};
+        const testResults = this.checkTestResults(response);
+        const oldTestResult = this.getTestResultToArchive(testResults);
+        oldTestResult.testVersion = TEST_VERSION.ARCHIVED;
+        const newTestResult: ITestResult = cloneDeep(oldTestResult);
+        newTestResult.testVersion = TEST_VERSION.CURRENT;
+        this.manageTestTypesToArchive(payload.testTypes, oldTestResult, newTestResult);
+        if (!newTestResult.testTypes.length) {
+          newTestResult.testVersion = TEST_VERSION.ARCHIVED;
+        }
+        newTestResult.reasonForCreation = this.getReasonForCreation(payload.reasonForCreation);
+        this.setAuditDetails(newTestResult, oldTestResult, msUserDetails);
+        this.manageTestHistoryArray(newTestResult, oldTestResult);
+        return this.testResultsDAO.updateTestResult(newTestResult)
+          .then((data) => {
+            return newTestResult;
+          }).catch((error) => {
+            throw new HTTPError(500, error.message);
+          });
+      }).catch((error) => {
+        throw new HTTPError(error.statusCode, error.body);
+      });
+  }
+
+  private mapErrorMessage(validation: ValidationResult<any> | any ) {
+    return validation.error.details.map((detail: { message: string; }) => {
+      return detail.message;
+    });
+  }
+
+  private manageDefectsArray(testResult: ITestResult) {
+    testResult.testTypes.forEach((testType: TestType) => {
+      if (SPECIALIST_TEST_TYPE_IDS.includes(testType.testTypeId)) {
+        testType.defects = [];
+      }
+    });
+  }
+
+  private manageTestHistoryArray(newTestResult: ITestResult, oldTestResult: ITestResult) {
+    if (!newTestResult.testHistory) {
+      newTestResult.testHistory = [oldTestResult];
+    } else {
+      delete oldTestResult.testHistory;
+      newTestResult.testHistory.push(oldTestResult);
+    }
+  }
+
+  private getReasonForCreation(reasonForCreation: string | undefined) {
+    const reasonForCreationValidation = Joi.object().keys({
+      reasonForCreation: Joi.string().max(500).required()
+    }).validate({reasonForCreation});
+    if (reasonForCreationValidation.error) {
+      throw new HTTPError(400, {errors: this.mapErrorMessage(reasonForCreationValidation)});
+    }
+    return reasonForCreation;
+  }
+
+  private manageTestTypesToArchive(newTestTypes: TestType[], oldTestResult: ITestResult, newTestResult: ITestResult) {
+    const testTypesToArchive = newTestTypes.filter((testType: TestType) => testType.statusUpdatedFlag === true);
+    if (!testTypesToArchive.length) {
+      throw new HTTPError(400, ERRORS.NoTestTypesToArchive);
+    }
+    testTypesToArchive.forEach((testType: TestType) => {
+      const testTypeFromDb = oldTestResult.testTypes.find((oldTestType: TestType) => oldTestType.testNumber === testType.testNumber);
+      if (!testTypeFromDb) {
+        throw new HTTPError(400, ERRORS.TestTypeToArchiveNotFound);
+      }
+      testTypeFromDb.statusUpdatedFlag = true;
+      testTypeFromDb.lastUpdatedAt = new Date().toISOString();
+      // removing the archived test type from the current test-result object
+      newTestResult.testTypes = newTestResult.testTypes.filter((testTypeToRemove: TestType) => testTypeToRemove.testNumber !== testTypeFromDb.testNumber);
+    });
   }
 
   private arrayCustomizer(objValue: any, srcValue: any) {
@@ -353,9 +413,9 @@ export class TestResultsService {
     return validationErrors;
   }
 
-  public getTestResultToArchive(testResults: ITestResult[], testResultId: string): ITestResult {
+  public getTestResultToArchive(testResults: ITestResult[]): ITestResult {
     testResults = testResults.filter((testResult) => {
-      return testResult.testResultId === testResultId && (testResult.testVersion === TEST_VERSION.CURRENT || !testResult.testVersion);
+      return (testResult.testVersion === TEST_VERSION.CURRENT || !testResult.testVersion);
     });
     if (testResults.length !== 1) {
       throw new HTTPError(404, ERRORS.NoResourceMatch);

--- a/src/utils/formatErrorMessage.ts
+++ b/src/utils/formatErrorMessage.ts
@@ -1,0 +1,5 @@
+export const formatErrorMessage = (errorMessage: string) => {
+  return {
+    errors: Array.of(errorMessage)
+  };
+};

--- a/tests/resources/test-results.json
+++ b/tests/resources/test-results.json
@@ -3137,7 +3137,8 @@
     "numberOfSeats": 45,
     "noOfAxles": 2,
     "testerEmailAddress": "dorel.ionescu@dvsagov.uk",
-    "euVehicleCategory": "m2"
+    "euVehicleCategory": "m2",
+    "reasonForCreation": "For testing"
   },
   {
     "testResultId": "23",

--- a/tests/unit/archiveTestResults.unitTest.ts
+++ b/tests/unit/archiveTestResults.unitTest.ts
@@ -1,0 +1,237 @@
+import {TestResultsService} from "../../src/services/TestResultsService";
+import {HTTPError} from "../../src/models/HTTPError";
+import testResults from "../resources/test-results.json";
+import {ERRORS, MESSAGES} from "../../src/assets/Enums";
+import {cloneDeep} from "lodash";
+
+describe("archiveTestResults", () => {
+  let testResultsService: TestResultsService | any;
+  let MockTestResultsDAO: jest.Mock;
+  let testResultsMockDB: any;
+  let testToUpdate: any;
+  let testType: any;
+  const msUserDetails = {
+    msUser: "dorel",
+    msOid: "123456"
+  };
+  beforeEach(() => {
+    testResultsMockDB = testResults;
+    MockTestResultsDAO = jest.fn().mockImplementation(() => {
+      return {};
+    });
+    testResultsService = new TestResultsService(new MockTestResultsDAO());
+    testToUpdate = cloneDeep(testResultsMockDB[30]);
+    testType = cloneDeep(testToUpdate.testTypes[0]);
+    testType.testNumber = Date.now().toString();
+    testToUpdate.testTypes[0].statusUpdatedFlag = true;
+    testToUpdate.testTypes.push(testType);
+  });
+
+  afterEach(() => {
+    testResultsMockDB = null;
+    testResultsService = null;
+    testToUpdate = null;
+    testType = null;
+    MockTestResultsDAO.mockReset();
+  });
+
+  context("when trying to archive a test-type", () => {
+    it("should return the updated test-result without the archived testType", () => {
+      MockTestResultsDAO = jest.fn().mockImplementation(() => {
+        return {
+          updateTestResult: () => {
+            return Promise.resolve({});
+          },
+          getByTestResultId: () => {
+            return Promise.resolve({
+              Items: Array.of(cloneDeep(testToUpdate)),
+              Count: 1
+            });
+          }
+        };
+      });
+
+      testResultsService = new TestResultsService(new MockTestResultsDAO());
+      return testResultsService.archiveTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
+        .then((returnedRecord: any) => {
+          expect(returnedRecord).not.toEqual(undefined);
+          expect(returnedRecord).not.toEqual({});
+          expect(returnedRecord).toHaveProperty("createdAt");
+          expect(returnedRecord).toHaveProperty("createdById");
+          expect(returnedRecord).toHaveProperty("createdByName");
+          expect(returnedRecord).toHaveProperty("testVersion");
+          expect(returnedRecord).toHaveProperty("reasonForCreation");
+          expect(returnedRecord.testVersion).toEqual("current");
+          expect(returnedRecord.testTypes.length).toEqual(1);
+          expect(returnedRecord).toHaveProperty("testHistory");
+          expect(returnedRecord.testHistory[0].testVersion).toEqual("archived");
+          expect(returnedRecord.testHistory[0].testTypes.length).toEqual(2);
+          expect(returnedRecord.testHistory[0].testTypes[0]).toHaveProperty("statusUpdatedFlag");
+          expect(returnedRecord.testHistory[0].testTypes[0].statusUpdatedFlag).toEqual(true);
+          expect(returnedRecord.testHistory[0].testTypes[1]).not.toHaveProperty("statusUpdatedFlag");
+        });
+    });
+
+    context("when we are archiving all test-types", () => {
+      it("should remove all the test-types from the testType array and mark the test-result as ARCHIVED", () => {
+        MockTestResultsDAO = jest.fn().mockImplementation(() => {
+          return {
+            updateTestResult: () => {
+              return Promise.resolve({});
+            },
+            getByTestResultId: () => {
+              return Promise.resolve({
+                Items: Array.of(cloneDeep(testToUpdate)),
+                Count: 1
+              });
+            }
+          };
+        });
+
+        testResultsService = new TestResultsService(new MockTestResultsDAO());
+        testToUpdate.testTypes[1].statusUpdatedFlag = true;
+        return testResultsService.archiveTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
+          .then((returnedRecord: any) => {
+            expect(returnedRecord).not.toEqual(undefined);
+            expect(returnedRecord).not.toEqual({});
+            expect(returnedRecord).toHaveProperty("createdAt");
+            expect(returnedRecord).toHaveProperty("createdById");
+            expect(returnedRecord).toHaveProperty("createdByName");
+            expect(returnedRecord).toHaveProperty("testVersion");
+            expect(returnedRecord).toHaveProperty("reasonForCreation");
+            expect(returnedRecord.testVersion).toEqual("archived");
+            expect(returnedRecord.testTypes.length).toEqual(0);
+            expect(returnedRecord).toHaveProperty("testHistory");
+            expect(returnedRecord.testHistory[0].testVersion).toEqual("archived");
+            expect(returnedRecord.testHistory[0].testTypes.length).toEqual(2);
+            expect(returnedRecord.testHistory[0].testTypes[0]).toHaveProperty("statusUpdatedFlag");
+            expect(returnedRecord.testHistory[0].testTypes[0].statusUpdatedFlag).toEqual(true);
+            expect(returnedRecord.testHistory[0].testTypes[1]).toHaveProperty("statusUpdatedFlag");
+            expect(returnedRecord.testHistory[0].testTypes[1].statusUpdatedFlag).toEqual(true);
+          });
+      });
+    });
+
+    context("when trying to archive a test-type that's not found on the test-result object", () => {
+      it("should throw an error 400 Test type to archive not found", () => {
+        MockTestResultsDAO = jest.fn().mockImplementation(() => {
+          return {
+            getByTestResultId: () => {
+              return Promise.resolve({
+                Items: Array.of(cloneDeep(testResultsMockDB[0])),
+                Count: 1
+              });
+            }
+          };
+        });
+
+        testResultsService = new TestResultsService(new MockTestResultsDAO());
+        return testResultsService.archiveTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
+          .catch((errorResponse: { statusCode: any; body: any; }) => {
+            expect(errorResponse).toBeInstanceOf(HTTPError);
+            expect(errorResponse.statusCode).toEqual(400);
+            expect(errorResponse.body).toEqual(ERRORS.TestTypeToArchiveNotFound);
+          });
+      });
+    });
+
+    context("when statusUpdatedFlag is not set to true on any of the test-types", () => {
+      it("should throw an error 400 No test types to archive", () => {
+        MockTestResultsDAO = jest.fn().mockImplementation(() => {
+          return {
+            getByTestResultId: () => {
+              return Promise.resolve({
+                Items: Array.of(cloneDeep(testToUpdate)),
+                Count: 1
+              });
+            }
+          };
+        });
+
+        testResultsService = new TestResultsService(new MockTestResultsDAO());
+        testToUpdate.testTypes[0].statusUpdatedFlag = false;
+        return testResultsService.archiveTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
+          .catch((errorResponse: { statusCode: any; body: any; }) => {
+            expect(errorResponse).toBeInstanceOf(HTTPError);
+            expect(errorResponse.statusCode).toEqual(400);
+            expect(errorResponse.body).toEqual(ERRORS.NoTestTypesToArchive);
+          });
+      });
+    });
+
+    context("when reasonForCreation is sent as empty string", () => {
+      it("should throw an error 400 Reason for creation is invalid", () => {
+        MockTestResultsDAO = jest.fn().mockImplementation(() => {
+          return {
+            getByTestResultId: () => {
+              return Promise.resolve({
+                Items: Array.of(cloneDeep(testToUpdate)),
+                Count: 1
+              });
+            }
+          };
+        });
+
+        testResultsService = new TestResultsService(new MockTestResultsDAO());
+        testToUpdate.reasonForCreation = "";
+        return testResultsService.archiveTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
+          .catch((errorResponse: { statusCode: any; body: any; }) => {
+            expect(errorResponse).toBeInstanceOf(HTTPError);
+            expect(errorResponse.statusCode).toEqual(400);
+            expect(errorResponse.body.errors).toContain("\"reasonForCreation\" is not allowed to be empty");
+          });
+      });
+    });
+
+    context("when updateTestResultDAO throws error", () => {
+      it("should throw an error 500-Internal Error", () => {
+        MockTestResultsDAO = jest.fn().mockImplementation(() => {
+          return {
+            updateTestResult: () => {
+              return Promise.reject({statusCode: 500, message: MESSAGES.INTERNAL_SERVER_ERROR});
+            },
+            getByTestResultId: () => {
+              return Promise.resolve({
+                Items: Array.of(testToUpdate),
+                Count: 1
+              });
+            }
+          };
+        });
+
+        testResultsService = new TestResultsService(new MockTestResultsDAO());
+        expect.assertions(3);
+        return testResultsService.archiveTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
+          .catch((errorResponse: { statusCode: any; body: any; }) => {
+            expect(errorResponse).toBeInstanceOf(HTTPError);
+            expect(errorResponse.statusCode).toEqual(500);
+            expect(errorResponse.body).toEqual(MESSAGES.INTERNAL_SERVER_ERROR);
+          });
+      });
+    });
+
+    context("when no data was found", () => {
+      it("should throw an error 404-No resources match the search criteria", () => {
+        MockTestResultsDAO = jest.fn().mockImplementation(() => {
+          return {
+            getByTestResultId: () => {
+              return Promise.resolve({
+                Items: [],
+                Count: 0
+              });
+            }
+          };
+        });
+
+        testResultsService = new TestResultsService(new MockTestResultsDAO());
+        expect.assertions(3);
+        return testResultsService.archiveTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
+          .catch((errorResponse: { statusCode: any; body: any; }) => {
+            expect(errorResponse).toBeInstanceOf(HTTPError);
+            expect(errorResponse.statusCode).toEqual(404);
+            expect(errorResponse.body).toEqual(ERRORS.NoResourceMatch);
+          });
+      });
+    });
+  });
+});

--- a/tests/unit/archiveTestResultsFunction.unitTest.ts
+++ b/tests/unit/archiveTestResultsFunction.unitTest.ts
@@ -1,0 +1,93 @@
+import {archiveTestResults} from "../../src/functions/archiveTestResults";
+import {TestResultsService} from "../../src/services/TestResultsService";
+import {HTTPResponse} from "../../src/models/HTTPResponse";
+import {HTTPError} from "../../src/models/HTTPError";
+jest.mock("../../src/services/TestResultsService");
+
+describe("archiveTestResults Function", () => {
+  let event: any;
+  beforeEach(() => {
+    event = {
+      pathParameters: {
+        testResultId: 1
+      },
+      body: {}
+    };
+  });
+
+  afterEach(() => {
+    event = null;
+  });
+
+  context("when testResult object is not present on the payload", () => {
+    it("should return Error 400 Bad request test-result object not provided", async () => {
+      const testResultsMock = jest.fn().mockResolvedValue("Failure");
+      TestResultsService.prototype.archiveTestResult = testResultsMock;
+
+      expect.assertions(3);
+      const result = await archiveTestResults(event);
+      expect(result).toBeInstanceOf(HTTPResponse);
+      expect(result.statusCode).toEqual(400);
+      expect(JSON.parse(result.body).errors).toContain("Bad request test-result object not provided");
+    });
+  });
+
+  context("when VIN is not present on the payload", () => {
+    it("should return Error 400 Bad request VIN not provided", async () => {
+      const testResultsMock = jest.fn().mockResolvedValue("Failure");
+      TestResultsService.prototype.archiveTestResult = testResultsMock;
+      event.body.testResult = "something";
+
+      expect.assertions(3);
+      const result = await archiveTestResults(event);
+      expect(result).toBeInstanceOf(HTTPResponse);
+      expect(result.statusCode).toEqual(400);
+      expect(JSON.parse(result.body).errors).toContain("Bad request VIN not provided");
+    });
+  });
+
+  context("when msUserDetails object is not present on the payload", () => {
+    it("should return Error 400 Bad request msUserDetails not provided", async () => {
+      const testResultsMock = jest.fn().mockResolvedValue("Failure");
+      TestResultsService.prototype.archiveTestResult = testResultsMock;
+      event.body.testResult = {vin: "something"};
+
+      expect.assertions(3);
+      const result = await archiveTestResults(event);
+      expect(result).toBeInstanceOf(HTTPResponse);
+      expect(result.statusCode).toEqual(400);
+      expect(JSON.parse(result.body).errors).toContain("Bad request msUserDetails not provided");
+    });
+  });
+
+  context("Service call fails", () => {
+    it("returns Error", async () => {
+      const myError = new HTTPError(418, "It Broke!");
+      TestResultsService.prototype.archiveTestResult = jest.fn().mockRejectedValue(myError);
+      event.body.testResult = {vin: "something"};
+      event.body.msUserDetails = {msOid: "2", msUser: "dorel"};
+
+      expect.assertions(3);
+      const result = await archiveTestResults(event);
+      expect(result).toBeInstanceOf(HTTPResponse);
+      expect(result.statusCode).toEqual(418);
+      expect(result.body).toEqual(JSON.stringify("It Broke!"));
+    });
+  });
+
+  context("Service call succeeds", () => {
+    it("returns 200 + data", async () => {
+      const testResultsMock = jest.fn().mockResolvedValue("Success");
+      TestResultsService.prototype.archiveTestResult = testResultsMock;
+
+      event.body.testResult = {vin: "something"};
+      event.body.msUserDetails = {msOid: "2", msUser: "dorel"};
+
+      expect.assertions(3);
+      const result = await archiveTestResults(event);
+      expect(result).toBeInstanceOf(HTTPResponse);
+      expect(result.statusCode).toEqual(200);
+      expect(result.body).toEqual(JSON.stringify("Success"));
+    });
+  });
+});

--- a/tests/unit/configuration.unitTest.ts
+++ b/tests/unit/configuration.unitTest.ts
@@ -6,11 +6,12 @@ describe("The configuration service", () => {
             process.env.BRANCH = "local";
             const configService = Configuration.getInstance();
             const functions = configService.getFunctions();
-            expect(functions.length).toEqual(4);
+            expect(functions.length).toEqual(5);
             expect(functions[0].name).toEqual("postTestResults");
             expect(functions[1].name).toEqual("getTestResultsBySystemNumber");
             expect(functions[2].name).toEqual("getTestResultsByTesterStaffId");
             expect(functions[3].name).toEqual("updateTestResults");
+            expect(functions[4].name).toEqual("archiveTestResults");
 
 
             const DBConfig = configService.getDynamoDBConfig();
@@ -23,11 +24,12 @@ describe("The configuration service", () => {
             process.env.BRANCH = "local-global";
             const configService = Configuration.getInstance();
             const functions = configService.getFunctions();
-            expect(functions.length).toEqual(4);
+            expect(functions.length).toEqual(5);
             expect(functions[0].name).toEqual("postTestResults");
             expect(functions[1].name).toEqual("getTestResultsBySystemNumber");
             expect(functions[2].name).toEqual("getTestResultsByTesterStaffId");
             expect(functions[3].name).toEqual("updateTestResults");
+            expect(functions[4].name).toEqual("archiveTestResults");
 
             const DBConfig = configService.getDynamoDBConfig();
             expect(DBConfig).toEqual(configService.getConfig().dynamodb["local-global"]);
@@ -39,11 +41,12 @@ describe("The configuration service", () => {
             process.env.BRANCH = "CVSB-XXX";
             const configService = Configuration.getInstance();
             const functions = configService.getFunctions();
-            expect(functions.length).toEqual(4);
+            expect(functions.length).toEqual(5);
             expect(functions[0].name).toEqual("postTestResults");
             expect(functions[1].name).toEqual("getTestResultsBySystemNumber");
             expect(functions[2].name).toEqual("getTestResultsByTesterStaffId");
             expect(functions[3].name).toEqual("updateTestResults");
+            expect(functions[4].name).toEqual("archiveTestResults");
 
             const DBConfig = configService.getDynamoDBConfig();
             expect(DBConfig).toEqual(configService.getConfig().dynamodb.remote);

--- a/tests/unit/updateTestResults.unitTest.ts
+++ b/tests/unit/updateTestResults.unitTest.ts
@@ -44,7 +44,7 @@ describe("updateTestResults", () => {
                                     endTime: "2020-04-22"
                                 }]);
                             },
-                            getBySystemNumber: () => {
+                            getByTestResultId: () => {
                                 return Promise.resolve({
                                     Items: Array.of(cloneDeep(testToUpdate)),
                                     Count: 1
@@ -55,7 +55,7 @@ describe("updateTestResults", () => {
 
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
                     expect.assertions(9);
-                    return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                    return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                         .then((returnedRecord: any) => {
                             expect(returnedRecord).not.toEqual(undefined);
                             expect(returnedRecord).not.toEqual({});
@@ -83,7 +83,7 @@ describe("updateTestResults", () => {
                                             endTime: "2020-04-22"
                                         }]);
                                     },
-                                    getBySystemNumber: () => {
+                                    getByTestResultId: () => {
                                         return Promise.resolve({
                                             Items: Array.of(cloneDeep(testToUpdate)),
                                             Count: 1
@@ -102,7 +102,7 @@ describe("updateTestResults", () => {
                             const updatedPayload: any = cloneDeep(testResultsMockDB[30]);
                             updatedPayload.testTypes[0].testTypeName = "Another test type name";
                             expect.assertions(4);
-                            return testResultsService.updateTestResult(updatedPayload.systemNumber, updatedPayload, msUserDetails)
+                            return testResultsService.updateTestResult(updatedPayload.testResultId, updatedPayload, msUserDetails)
                               .then((returnedRecord: any) => {
                                   expect(returnedRecord).not.toEqual(undefined);
                                   expect(returnedRecord).not.toEqual({});
@@ -125,7 +125,7 @@ describe("updateTestResults", () => {
                                             endTime: "2020-04-22"
                                         }]);
                                     },
-                                    getBySystemNumber: () => {
+                                    getByTestResultId: () => {
                                         return Promise.resolve({
                                             Items: Array.of(cloneDeep(testToUpdate)),
                                             Count: 1
@@ -146,7 +146,7 @@ describe("updateTestResults", () => {
                             updatedPayload.vehicleSize = "large";
                             updatedPayload.noOfAxles = "4";
                             expect.assertions(4);
-                            return testResultsService.updateTestResult(updatedPayload.systemNumber, updatedPayload, msUserDetails)
+                            return testResultsService.updateTestResult(updatedPayload.testResultId, updatedPayload, msUserDetails)
                               .then((returnedRecord: any) => {
                                   expect(returnedRecord).not.toEqual(undefined);
                                   expect(returnedRecord).not.toEqual({});
@@ -171,7 +171,7 @@ describe("updateTestResults", () => {
                                             endTime: "2019-01-14T20:00:33.987Z"
                                         }]);
                                     },
-                                    getBySystemNumber: () => {
+                                    getByTestResultId: () => {
                                         return Promise.resolve({
                                             Items: Array.of(cloneDeep(testToUpdate)),
                                             Count: 1
@@ -183,7 +183,7 @@ describe("updateTestResults", () => {
                             testResultsService = new TestResultsService(new MockTestResultsDAO());
                             testToUpdate.testTypes[0].testTypeStartTimestamp = "2019-01-13T08:36:33.987Z";
                             expect.assertions(3);
-                            return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                            return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                               .catch((errorResponse: { statusCode: any; body: any; }) => {
                                   expect(errorResponse).toBeInstanceOf(HTTPError);
                                   expect(errorResponse.statusCode).toEqual(400);
@@ -202,7 +202,7 @@ describe("updateTestResults", () => {
                                             endTime: "2019-01-14T20:00:33.987Z"
                                         }]);
                                     },
-                                    getBySystemNumber: () => {
+                                    getByTestResultId: () => {
                                         return Promise.resolve({
                                             Items: Array.of(cloneDeep(testToUpdate)),
                                             Count: 1
@@ -214,7 +214,7 @@ describe("updateTestResults", () => {
                             testResultsService = new TestResultsService(new MockTestResultsDAO());
                             testToUpdate.testTypes[0].testTypeStartTimestamp = "2019-01-14T21:00:33.987Z";
                             expect.assertions(3);
-                            return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                            return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                               .catch((errorResponse: { statusCode: any; body: any; }) => {
                                   expect(errorResponse).toBeInstanceOf(HTTPError);
                                   expect(errorResponse.statusCode).toEqual(400);
@@ -233,7 +233,7 @@ describe("updateTestResults", () => {
                                             endTime: "2019-01-14T20:00:33.987Z"
                                         }]);
                                     },
-                                    getBySystemNumber: () => {
+                                    getByTestResultId: () => {
                                         return Promise.resolve({
                                             Items: Array.of(cloneDeep(testToUpdate)),
                                             Count: 1
@@ -245,7 +245,7 @@ describe("updateTestResults", () => {
                             testResultsService = new TestResultsService(new MockTestResultsDAO());
                             testToUpdate.testTypes[0].testTypeEndTimestamp = "2019-01-13T18:00:33.987Z";
                             expect.assertions(3);
-                            return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                            return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                               .catch((errorResponse: { statusCode: any; body: any; }) => {
                                   expect(errorResponse).toBeInstanceOf(HTTPError);
                                   expect(errorResponse.statusCode).toEqual(400);
@@ -264,7 +264,7 @@ describe("updateTestResults", () => {
                                             endTime: "2019-01-14T20:00:33.987Z"
                                         }]);
                                     },
-                                    getBySystemNumber: () => {
+                                    getByTestResultId: () => {
                                         return Promise.resolve({
                                             Items: Array.of(cloneDeep(testToUpdate)),
                                             Count: 1
@@ -276,7 +276,7 @@ describe("updateTestResults", () => {
                             testResultsService = new TestResultsService(new MockTestResultsDAO());
                             testToUpdate.testTypes[0].testTypeEndTimestamp = "2019-01-15T18:00:33.987Z";
                             expect.assertions(3);
-                            return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                            return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                               .catch((errorResponse: { statusCode: any; body: any; }) => {
                                   expect(errorResponse).toBeInstanceOf(HTTPError);
                                   expect(errorResponse.statusCode).toEqual(400);
@@ -295,7 +295,7 @@ describe("updateTestResults", () => {
                                             endTime: "2019-01-14T20:00:33.987Z"
                                         }]);
                                     },
-                                    getBySystemNumber: () => {
+                                    getByTestResultId: () => {
                                         return Promise.resolve({
                                             Items: Array.of(cloneDeep(testToUpdate)),
                                             Count: 1
@@ -308,7 +308,7 @@ describe("updateTestResults", () => {
                             testToUpdate.testTypes[0].testTypeEndTimestamp = "2019-01-14T16:00:33.987Z";
                             testToUpdate.testTypes[0].testTypeStartTimestamp = "2019-01-14T18:00:33.987Z";
                             expect.assertions(3);
-                            return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                            return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                               .catch((errorResponse: { statusCode: any; body: any; }) => {
                                   expect(errorResponse).toBeInstanceOf(HTTPError);
                                   expect(errorResponse.statusCode).toEqual(400);
@@ -324,7 +324,7 @@ describe("updateTestResults", () => {
                                     getActivity: () => {
                                         return Promise.resolve(["firstActivity", "secondActivity"]);
                                     },
-                                    getBySystemNumber: () => {
+                                    getByTestResultId: () => {
                                         return Promise.resolve({
                                             Items: Array.of(cloneDeep(testToUpdate)),
                                             Count: 1
@@ -335,7 +335,7 @@ describe("updateTestResults", () => {
 
                             testResultsService = new TestResultsService(new MockTestResultsDAO());
                             expect.assertions(3);
-                            return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                            return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                               .catch((errorResponse: { statusCode: any; body: any; }) => {
                                   expect(errorResponse).toBeInstanceOf(HTTPError);
                                   expect(errorResponse.statusCode).toEqual(500);
@@ -351,7 +351,7 @@ describe("updateTestResults", () => {
                                     getActivity: () => {
                                         return Promise.reject({statusCode: 400, body: ERRORS.EventIsEmpty});
                                     },
-                                    getBySystemNumber: () => {
+                                    getByTestResultId: () => {
                                         return Promise.resolve({
                                             Items: Array.of(cloneDeep(testToUpdate)),
                                             Count: 1
@@ -362,7 +362,7 @@ describe("updateTestResults", () => {
 
                             testResultsService = new TestResultsService(new MockTestResultsDAO());
                             expect.assertions(3);
-                            return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                            return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                               .catch((errorResponse: { statusCode: any; body: any; }) => {
                                   expect(errorResponse).toBeInstanceOf(HTTPError);
                                   expect(errorResponse.statusCode).toEqual(400);
@@ -378,7 +378,7 @@ describe("updateTestResults", () => {
                                     getActivity: () => {
                                         return Promise.reject({statusCode: 404, body: ERRORS.NoResourceMatch});
                                     },
-                                    getBySystemNumber: () => {
+                                    getByTestResultId: () => {
                                         return Promise.resolve({
                                             Items: Array.of(cloneDeep(testToUpdate)),
                                             Count: 1
@@ -402,7 +402,7 @@ describe("updateTestResults", () => {
                             testToUpdate.testTypes[0].testTypeStartTimestamp = expectedTestTypeStartTimestamp;
                             testToUpdate.testTypes[0].testTypeEndTimestamp = expectedTestTypeEndTimestamp;
                             expect.assertions(4);
-                            return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                            return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                               .then((returnedRecord: any) => {
                                   expect(returnedRecord).not.toEqual(undefined);
                                   expect(returnedRecord).not.toEqual({});
@@ -430,7 +430,7 @@ describe("updateTestResults", () => {
                                     endTime: "2020-04-22"
                                 }]);
                             },
-                            getBySystemNumber: () => {
+                            getByTestResultId: () => {
                                 return Promise.resolve({
                                     Items: Array.of(existingTest),
                                     Count: 1
@@ -441,7 +441,7 @@ describe("updateTestResults", () => {
 
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
                     expect.assertions(3);
-                    return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                    return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                         .catch((errorResponse: { statusCode: any; body: any; }) => {
                             expect(errorResponse).toBeInstanceOf(HTTPError);
                             expect(errorResponse.statusCode).toEqual(500);
@@ -454,7 +454,7 @@ describe("updateTestResults", () => {
                 it("should throw an error 404-No resources match the search criteria", () => {
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
-                            getBySystemNumber: () => {
+                            getByTestResultId: () => {
                                 return Promise.resolve({
                                     Items: [],
                                     Count: 0
@@ -465,7 +465,7 @@ describe("updateTestResults", () => {
 
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
                     expect.assertions(3);
-                    return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                    return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                         .catch((errorResponse: { statusCode: any; body: any; }) => {
                             expect(errorResponse).toBeInstanceOf(HTTPError);
                             expect(errorResponse.statusCode).toEqual(404);
@@ -478,10 +478,10 @@ describe("updateTestResults", () => {
                 it("should throw an error 404-No resources match the search criteria", () => {
                     MockTestResultsDAO = jest.fn().mockImplementation(() => {
                         return {
-                            getBySystemNumber: () => {
+                            getByTestResultId: () => {
                                 return Promise.resolve({
-                                    Items: Array.of(testResultsMockDB[0]),
-                                    Count: 1
+                                    Items: Array.of(testResultsMockDB[0], testResultsMockDB[1]),
+                                    Count: 2
                                 });
                             }
                         };
@@ -489,7 +489,7 @@ describe("updateTestResults", () => {
 
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
                     expect.assertions(3);
-                    return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                    return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                         .catch((errorResponse: { statusCode: any; body: any; }) => {
                             expect(errorResponse).toBeInstanceOf(HTTPError);
                             expect(errorResponse.statusCode).toEqual(404);
@@ -507,7 +507,7 @@ describe("updateTestResults", () => {
                         updateTestResult: () => {
                             return Promise.resolve({});
                         },
-                        getBySystemNumber: () => {
+                        getByTestResultId: () => {
                             return Promise.resolve({
                                 Items: Array.of(testToUpdate),
                                 Count: 1
@@ -518,7 +518,7 @@ describe("updateTestResults", () => {
 
                 testResultsService = new TestResultsService(new MockTestResultsDAO());
                 testToUpdate.vehicleType = "trl";
-                return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                     .catch((errorResponse: { statusCode: any; body: any; }) => {
                         expect(errorResponse).toBeInstanceOf(HTTPError);
                         expect(errorResponse.statusCode).toEqual(400);
@@ -533,7 +533,7 @@ describe("updateTestResults", () => {
                             updateTestResult: () => {
                                 return Promise.resolve({});
                             },
-                            getBySystemNumber: () => {
+                            getByTestResultId: () => {
                                 return Promise.resolve({
                                     Items: Array.of(testToUpdate),
                                     Count: 1
@@ -544,7 +544,7 @@ describe("updateTestResults", () => {
 
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
                     testToUpdate.euVehicleCategory = "invalid value";
-                    return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                    return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                       .catch((errorResponse: { statusCode: any; body: any; }) => {
                           expect(errorResponse).toBeInstanceOf(HTTPError);
                           expect(errorResponse.statusCode).toEqual(400);
@@ -559,7 +559,7 @@ describe("updateTestResults", () => {
                             updateTestResult: () => {
                                 return Promise.resolve({});
                             },
-                            getBySystemNumber: () => {
+                            getByTestResultId: () => {
                                 return Promise.resolve({
                                     Items: Array.of(testToUpdate),
                                     Count: 1
@@ -570,7 +570,7 @@ describe("updateTestResults", () => {
 
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
                     testToUpdate.testerStaffId = "invalid value exceeding size limit 123456789012343454";
-                    return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                    return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                       .catch((errorResponse: { statusCode: any; body: any; }) => {
                           expect(errorResponse).toBeInstanceOf(HTTPError);
                           expect(errorResponse.statusCode).toEqual(400);
@@ -588,7 +588,7 @@ describe("updateTestResults", () => {
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
                     testToUpdate = cloneDeep(testResultsMockDB[1]);
                     expect.assertions(4);
-                    return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                    return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                       .catch((errorResponse: { statusCode: any; body: any; }) => {
                           expect(errorResponse).toBeInstanceOf(HTTPError);
                           expect(errorResponse.statusCode).toEqual(400);
@@ -605,7 +605,7 @@ describe("updateTestResults", () => {
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
                     testToUpdate.testTypes[0].testTypeId = "unknown";
                     expect.assertions(3);
-                    return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                    return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                       .catch((errorResponse: { statusCode: any; body: any; }) => {
                           expect(errorResponse).toBeInstanceOf(HTTPError);
                           expect(errorResponse.statusCode).toEqual(400);
@@ -638,7 +638,7 @@ describe("updateTestResults", () => {
                     testResultsService = new TestResultsService(new MockTestResultsDAO());
                     delete testToUpdate.testTypes;
                     expect.assertions(3);
-                    return testResultsService.updateTestResult(testToUpdate.systemNumber, testToUpdate, msUserDetails)
+                    return testResultsService.updateTestResult(testToUpdate.testResultId, testToUpdate, msUserDetails)
                       .catch((errorResponse: { statusCode: any; body: any; }) => {
                           expect(errorResponse).toBeInstanceOf(HTTPError);
                           expect(errorResponse.statusCode).toEqual(400);

--- a/tests/unit/updateTestResultsFunction.unitTest.ts
+++ b/tests/unit/updateTestResultsFunction.unitTest.ts
@@ -9,7 +9,7 @@ describe("updateTestResults Function", () => {
     beforeEach(() => {
         event = {
             pathParameters: {
-                systemNumber: 1
+                testResultId: 1
             },
             body: {}
         };
@@ -20,7 +20,7 @@ describe("updateTestResults Function", () => {
     });
 
     context("when testResult object is not present on the payload", () => {
-        it("should return Error 400 Bad request testResult not provided", async () => {
+        it("should return Error 400 Bad request test-result object not provided", async () => {
             const testResultsMock = jest.fn().mockResolvedValue("Failure");
             TestResultsService.prototype.updateTestResult = testResultsMock;
 
@@ -28,7 +28,7 @@ describe("updateTestResults Function", () => {
             const result = await updateTestResults(event);
             expect(result).toBeInstanceOf(HTTPResponse);
             expect(result.statusCode).toEqual(400);
-            expect(result.body).toEqual(JSON.stringify("Bad request testResult not provided"));
+            expect(JSON.parse(result.body).errors).toContain("Bad request test-result object not provided");
         });
     });
 
@@ -42,7 +42,7 @@ describe("updateTestResults Function", () => {
             const result = await updateTestResults(event);
             expect(result).toBeInstanceOf(HTTPResponse);
             expect(result.statusCode).toEqual(400);
-            expect(result.body).toEqual(JSON.stringify("Bad request msUserDetails not provided"));
+            expect(JSON.parse(result.body).errors).toContain("Bad request msUserDetails not provided");
         });
     });
 


### PR DESCRIPTION
This ticket covers the ability for a user to archive a test type. A new CTA will be present on the test record view mode. A modal will appear once the user selects the new archive CTA where they can confirm to archive the test type they have selected.

'statusUpdatedFlag' - new attribute to identify which test type in a test result is to be archived

https://jira.dvsacloud.uk/browse/CVSB-14406