### PR TITLE
feat(cvsb-18931): update date validation and recent expiry logic - changes on branch 18928

### DIFF
--- a/src/handlers/expiry/providers/DateProvider.ts
+++ b/src/handlers/expiry/providers/DateProvider.ts
@@ -24,14 +24,22 @@ export class DateProvider {
     this.testDate = moment(date).startOf("day").toDate();
   }
 
-//#region Private Static Functions
+  //#region Static Functions
   public static getEpoc(): Date {
-  return moment(new Date(0)).startOf("day").toDate();
+    return moment(new Date(0)).startOf("day").toDate();
   }
+
   public static isSameAsEpoc(inputDate: Date): boolean {
     return moment(inputDate).isSame(DateProvider.getEpoc());
   }
 
+  public static getInstance(dateValue: string | number | Date) {
+    return moment(dateValue);
+  }
+
+  public static getMaxDate(arrayOfDates: moment.Moment[]) {
+    return  moment.max(arrayOfDates).toDate();
+  }
   /**
    * To validate whether provided input is a date. "undefined" is validated separately because moment(undefined) = new Date(). Strict validation is performed and only two date formats are acceptable YYYY-MM-DD and YYYY-MM-DDTHH:mm:ss.SSSZ.
    * @param input The input value which is validated.
@@ -41,12 +49,11 @@ export class DateProvider {
   ): boolean {
     return (
       input !== undefined &&
-      (
-        moment(input,  "YYYY-MM-DDTHH:mm:ss.SSSZ", true).isValid() ||
-        moment(input,  "YYYY-MM-DD", true).isValid()
-      ) &&
+      (moment(input, "YYYY-MM-DDTHH:mm:ss.SSSSSSZ", true).isValid() || // Legacy format
+        moment(input, "YYYY-MM-DDTHH:mm:ss.SSSZ", true).isValid() || //  Test result API format
+        moment(input, "YYYY-MM-DD", true).isValid()) && // Tech Record dates e.g. regnDate
       moment(input).isAfter(new Date(0))
-      );
+    );
   }
   /**
    * To compare whether input date is between two months of compare date. Inlcusivty parameter represents start and end of month.
@@ -59,7 +66,11 @@ export class DateProvider {
     compareDate: Date,
     inclusivity: "[]" | "()" | "[)" | "(]" | undefined
   ): boolean {
-    console.log(`compareDate+2 months: ${moment(compareDate).add(2, "months").toISOString()}`);
+    console.log(
+      `compareDate+2 months: ${moment(compareDate)
+        .add(2, "months")
+        .toISOString()}`
+    );
     return moment(inputDate).isBetween(
       moment(compareDate),
       moment(compareDate).add(2, "months"),
@@ -68,14 +79,35 @@ export class DateProvider {
     );
   }
 
+  /**
+   * To compare whether dates fall between a comparison period.
+   * @param fromDate the input from Date
+   * @param toDate the input to date
+   * @param compareFromDate the compare from Date
+   * @param compareToDate the compare to Date
+   */
+  public static isBetweenDates(
+    fromDate: string | number | Date,
+    toDate: string | number | Date,
+    compareFromDate: Date,
+    compareToDate: Date
+  ) {
+    return (
+      moment(fromDate).isAfter(compareFromDate) &&
+      moment(toDate).isBefore(compareToDate)
+    );
+  }
+
   public static addOneYear(inputDate: Date | string): Date {
-    return moment(inputDate)
-      .add(1, "years").startOf("day")
-      .toDate();
+    return moment(inputDate).add(1, "years").startOf("day").toDate();
   }
 
   public static addOneYearEndOfMonth(inputDate: Date | string): Date {
-    return moment(inputDate).add(1, "year").endOf("month").startOf("day").toDate();
+    return moment(inputDate)
+      .add(1, "year")
+      .endOf("month")
+      .startOf("day")
+      .toDate();
   }
 
   public static getEndOfMonth(inputDate: Date | string): Date {
@@ -83,19 +115,18 @@ export class DateProvider {
   }
 
   public static addOneYearISOString(inputDate: Date | string): string {
-    return moment(inputDate)
-      .add(1, "years")
-      .toISOString();
+    return moment(inputDate).add(1, "years").toISOString();
   }
 
-  public static addOneYearStartOfDayISOString(inputDate: Date | string): string {
-    return moment(inputDate)
-      .add(1, "year")
-      .startOf("day")
-      .toISOString();
+  public static addOneYearStartOfDayISOString(
+    inputDate: Date | string
+  ): string {
+    return moment(inputDate).add(1, "year").startOf("day").toISOString();
   }
 
-  public static addOneYearMinusOneDayISOString(inputDate: Date | string): string {
+  public static addOneYearMinusOneDayISOString(
+    inputDate: Date | string
+  ): string {
     return moment(inputDate)
       .add(1, "year")
       .subtract(1, "day")
@@ -103,12 +134,14 @@ export class DateProvider {
       .toISOString();
   }
 
-  public static getLastDayOfMonthInNextYearISOString(inputDate: Date | string): string {
+  public static getLastDayOfMonthInNextYearISOString(
+    inputDate: Date | string
+  ): string {
     return moment(inputDate)
       .add(1, "year")
       .endOf("month")
       .startOf("day")
       .toISOString();
   }
-//#endregion
+  //#endregion
 }

--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -611,10 +611,10 @@ export class TestResultsService {
           console.log(strategy.constructor.name);
           testType.testExpiryDate = strategy.getExpiryDate();
       });
-      console.log("generateExpiryDate payload", payload.testTypes);
+      console.log("generateExpiryDate: testTypes ->", payload.testTypes);
       return Promise.resolve(payload);
     } catch (error) {
-      console.error("Error in error generateExpiryDate", error);
+      console.error("generateExpiryDate: ", error);
       throw new HTTPError(500, MESSAGES.INTERNAL_SERVER_ERROR);
     }
 

--- a/tests/unit/expiry/TestDataProvider.unitTest.ts
+++ b/tests/unit/expiry/TestDataProvider.unitTest.ts
@@ -1,4 +1,4 @@
-import { MESSAGES, TEST_STATUS } from "../../../src/assets/Enums";
+import * as enums from "../../../src/assets/Enums";
 import { DateProvider } from "../../../src/handlers/expiry/providers/DateProvider";
 import { TestDataProvider } from "../../../src/handlers/expiry/providers/TestDataProvider";
 import { HTTPError } from "../../../src/models/HTTPError";
@@ -10,6 +10,7 @@ describe("TestDataProvider", () => {
   context("for getTestHistory", () => {
     describe("when getBySystemNumber returns error", () => {
       it("should throw error", async () => {
+        expect.assertions(1);
         try {
           testDataProvider = new TestDataProvider();
           MockTestResultsDAO = jest.fn().mockImplementation(() => {
@@ -22,25 +23,31 @@ describe("TestDataProvider", () => {
           testDataProvider.testResultsDAO = new MockTestResultsDAO();
           await testDataProvider.getTestHistory("123");
         } catch (error) {
-          expect.assertions(1);
           expect(error).toEqual(
-            new HTTPError(500, MESSAGES.INTERNAL_SERVER_ERROR)
+            new HTTPError(500, enums.MESSAGES.INTERNAL_SERVER_ERROR)
           );
         }
       });
     });
-    describe("when getBySystemNumber returns invalid testEndTimestamp", () => {
+    describe("when getBySystemNumber returns invalid testStartTimestamp", () => {
       it("should throw error", async () => {
+        expect.assertions(1);
         try {
           testDataProvider = new TestDataProvider();
           MockTestResultsDAO = jest.fn().mockImplementation(() => {
             return {
               getBySystemNumber: () => {
                 return {
-                  testStartTimestamp: "2019-10-10T08:47:59.269Z",
-                  testEndTimestamp: "2019-10",
-                  testTypes: [
-                    { testCode: "aat1", testExpiryDate: "2020-10-10" }
+                  Count: 1,
+                  Items: [
+                    {
+                      testStartTimestamp: "2019-03-10T08:47:59.269Z",
+                      testEndTimestamp: "2019-03",
+                      testTypes: [
+                        { testCode: "fft1", testExpiryDate: "2019-02-10T08:47:59.261009Z" }
+                      ],
+                      testStatus: enums.TEST_STATUS.SUBMITTED
+                    }
                   ]
                 };
               }
@@ -49,17 +56,87 @@ describe("TestDataProvider", () => {
           testDataProvider.testResultsDAO = new MockTestResultsDAO();
           await testDataProvider.getTestHistory("123");
         } catch (error) {
-          expect.assertions(1);
           expect(error).toEqual(
-            new HTTPError(500, MESSAGES.INTERNAL_SERVER_ERROR)
+            new HTTPError(500, enums.MESSAGES.INTERNAL_SERVER_ERROR)
           );
         }
+      });
+    });
+    describe("when getBySystemNumber returns invalid testEndTimestamp", () => {
+      it("should throw error", async () => {
+        expect.assertions(1);
+        try {
+          testDataProvider = new TestDataProvider();
+          MockTestResultsDAO = jest.fn().mockImplementation(() => {
+            return {
+              getBySystemNumber: () => {
+                return {
+                  Count: 1,
+                  Items: [
+                    {
+                      testStartTimestamp: "2019-03",
+                      testEndTimestamp: "2019-03-10T08:47:59.269Z",
+                      testTypes: [
+                        { testCode: "fft1", testExpiryDate: "2019-02-10T08:47:59.261009Z" }
+                      ],
+                      testStatus: enums.TEST_STATUS.SUBMITTED
+                    }
+                  ]
+                };
+              }
+            };
+          });
+          testDataProvider.testResultsDAO = new MockTestResultsDAO();
+          const result = await testDataProvider.getTestHistory("123");
+          console.log(result);
+        } catch (error) {
+          expect(error).toEqual(
+            new HTTPError(500, enums.MESSAGES.INTERNAL_SERVER_ERROR)
+          );
+        }
+      });
+    });
+    describe("when getBySystemNumber returns array of valid data", () => {
+      it("should return the filtered data", async () => {
+          expect.assertions(1);
+          testDataProvider = new TestDataProvider();
+          MockTestResultsDAO = jest.fn().mockImplementation(() => {
+            return {
+              getBySystemNumber: () => {
+                return {
+                  Count: 2,
+                  Items: [
+                    {
+                      testStartTimestamp: "2019-03-10T08:47:59.269Z",
+                      testEndTimestamp: "2019-03-10T09:30:59.269Z",
+                      testTypes: [
+                        { testCode: "fft1", testExpiryDate: "2019-02-10T08:47:59.261009Z" }
+                      ],
+                      testStatus: enums.TEST_STATUS.SUBMITTED
+                    },
+                    {
+                      testStartTimestamp: "2019-01-10T08:47:59.269000Z",
+                      testEndTimestamp: "2019-01-10T09:30:59.269000Z",
+                      testTypes: [
+                        { testCode: "rpt1", testExpiryDate: "2020-12-10T08:47:59.269000Z" }
+                      ],
+                      testStatus: enums.TEST_STATUS.SUBMITTED
+                    }
+                  ]
+                };
+              }
+            };
+          });
+          testDataProvider.testResultsDAO = new MockTestResultsDAO();
+          const result  = await testDataProvider.getTestHistory("123");
+          expect(result.length).toEqual(2);
       });
     });
   });
   context("for getMostRecentExpiryDate", () => {
     describe("when getBySystemNumber returns error", () => {
       it("should throw error", async () => {
+        expect.assertions(1);
         try {
           testDataProvider = new TestDataProvider();
           MockTestResultsDAO = jest.fn().mockImplementation(() => {
@@ -72,9 +149,8 @@ describe("TestDataProvider", () => {
           testDataProvider.testResultsDAO = new MockTestResultsDAO();
           await testDataProvider.getMostRecentExpiryDate("123");
         } catch (error) {
-          expect.assertions(1);
           expect(error).toEqual(
-            new HTTPError(500, MESSAGES.INTERNAL_SERVER_ERROR)
+            new HTTPError(500, enums.MESSAGES.INTERNAL_SERVER_ERROR)
           );
         }
       });
@@ -117,7 +193,7 @@ describe("TestDataProvider", () => {
                       testTypes: [
                         { testCode: "aat1", testExpiryDate: "2020-01-05" }
                       ],
-                      testStatus: TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED
                     },
                     {
                       testStartTimestamp: "2019-03-10T08:47:59.269Z",
@@ -125,7 +201,7 @@ describe("TestDataProvider", () => {
                       testTypes: [
                         { testCode: "fft1", testExpiryDate: "2020-02-15" }
                       ],
-                      testStatus: TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED
                     },
                     {
                       testStartTimestamp: "2019-01-10T08:47:59.269Z",
@@ -133,7 +209,7 @@ describe("TestDataProvider", () => {
                       testTypes: [
                         { testCode: "rpt1", testExpiryDate: "2020-01-04" }
                       ],
-                      testStatus: TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED
                     }
                   ]
                 };
@@ -149,7 +225,7 @@ describe("TestDataProvider", () => {
     });
 
     describe("when getBySystemNumber returns an array of valid and invalid recent expiry dates", () => {
-      it("should return the valid most recent expiry", async () => {
+      it("should throw error", async () => {
         testDataProvider = new TestDataProvider();
         MockTestResultsDAO = jest.fn().mockImplementation(() => {
           return {
@@ -164,7 +240,7 @@ describe("TestDataProvider", () => {
                       testTypes: [
                         { testCode: "aat1", testExpiryDate: "2020-01-05" }
                       ],
-                      testStatus: TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED
                     },
                     {
                       testStartTimestamp: "2019-03-10T08:47:59.269Z",
@@ -172,7 +248,7 @@ describe("TestDataProvider", () => {
                       testTypes: [
                         { testCode: "fft1", testExpiryDate: "2020-02-15" }
                       ],
-                      testStatus: TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED
                     },
                     {
                       testStartTimestamp: "2019-01-10T08:47:59.269Z",
@@ -180,7 +256,7 @@ describe("TestDataProvider", () => {
                       testTypes: [
                         { testCode: "rpt1", testExpiryDate: "2020-01" }
                       ],
-                      testStatus: TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED
                     }
                   ]
                 };
@@ -189,8 +265,60 @@ describe("TestDataProvider", () => {
           };
         });
         testDataProvider.testResultsDAO = new MockTestResultsDAO();
+        const expectedError = new Error("Invalid Expiry Date: 2020-01");
+        expect.assertions(1);
+        try {
+          await testDataProvider.getMostRecentExpiryDate("123");
+        } catch (error) {
+          expect(error).toEqual(expectedError);
+        }
+      });
+    });
+
+    describe("when getBySystemNumber returns an array of valid expiry dates with legacy history as well history based generated via VTA", () => {
+      it("should return the valid most recent expiry", async () => {
+        testDataProvider = new TestDataProvider();
+        MockTestResultsDAO = jest.fn().mockImplementation(() => {
+          return {
+            getBySystemNumber: () => {
+              {
+                return {
+                  Count: 3,
+                  Items: [
+                    {
+                      testStartTimestamp: "2019-02-10T08:47:59.269Z",
+                      testEndTimestamp: "2019-02-10T09:30:59.269Z",
+                      testTypes: [
+                        { testCode: "aat1", testExpiryDate: "2018-02-10T08:47:59.269Z" }
+                      ],
+                      testStatus: enums.TEST_STATUS.SUBMITTED
+                    },
+                    {
+                      testStartTimestamp: "2019-03-10T08:47:59.269Z",
+                      testEndTimestamp: "2019-03-10T09:30:59.269Z",
+                      testTypes: [
+                        { testCode: "fft1", testExpiryDate: "2019-02-10T08:47:59.261009Z" }
+                      ],
+                      testStatus: enums.TEST_STATUS.SUBMITTED
+                    },
+                    {
+                      testStartTimestamp: "2019-01-10T08:47:59.269Z",
+                      testEndTimestamp: "2019-01-10T09:30:59.269Z",
+                      testTypes: [
+                        { testCode: "rpt1", testExpiryDate: "2020-12-10T08:47:59.129000Z" }
+                      ],
+                      testStatus: enums.TEST_STATUS.SUBMITTED
+                    }
+                  ]
+                };
+              }
+            }
+          };
+        });
+        expect.assertions(1);
+        testDataProvider.testResultsDAO = new MockTestResultsDAO();
         const expiry = await testDataProvider.getMostRecentExpiryDate("123");
-        const expectedDate = new Date("2020-02-15");
+        const expectedDate = new Date("2020-12-10T08:47:59.129000Z");
         expect(expiry).toEqual(expectedDate);
       });
     });

--- a/tests/unit/expiry/TestDataProvider.unitTest.ts
+++ b/tests/unit/expiry/TestDataProvider.unitTest.ts
@@ -215,7 +215,7 @@ describe("TestDataProvider", () => {
       });
     });
 
-    describe("when getBySystemNumber returns an array of valid and invalid recent expiry dates", () => {
+    describe("when getBySystemNumber returns an array of invalid expiry dates including undefined", () => {
       it("should return the valid most recent expiry", async () => {
         testDataProvider = new TestDataProvider();
         MockTestResultsDAO = jest.fn().mockImplementation(() => {

--- a/tests/unit/generateExpiryDate.unitTest.ts
+++ b/tests/unit/generateExpiryDate.unitTest.ts
@@ -2,12 +2,12 @@ import {TestResultsService} from "../../src/services/TestResultsService";
 import fs from "fs";
 import path from "path";
 import {cloneDeep} from "lodash";
-import { COIF_EXPIRY_TEST_TYPES, MESSAGES } from "../../src/assets/Enums";
+import { COIF_EXPIRY_TEST_TYPES } from "../../src/assets/Enums";
 import dateMockUtils from "../util/dateMockUtils";
 import {ITestResult} from "../../src/models/ITestResult";
 import testResults from "../resources/test-results.json";
 import moment from "moment";
-import { HTTPError } from "../../src/models/HTTPError";
+
 
 describe("TestResultsService calling generateExpiryDate", () => {
     let testResultsService: TestResultsService | any;
@@ -550,7 +550,7 @@ describe("TestResultsService calling generateExpiryDate", () => {
             });
 
             describe("with only bad dates in the test history", () => {
-                it("should ignore the bad dates and set the expiry to 1 day short of a year from today", async () => {
+                it("should ignore the bad dates and set the expiry to 1 day short of a year from today", () => {
                     const psvTestResult = cloneDeep(testResultsMockDB[0]);
                     const getBySystemNumberResponse = cloneDeep(testResultsMockDB[0]) as ITestResult;
                     getBySystemNumberResponse.testTypes.forEach((test) => {
@@ -726,7 +726,7 @@ describe("TestResultsService calling generateExpiryDate", () => {
                     });
                 });
                 describe("and the previous expiry date is malformed", () => {
-                    it("should still set the expiry date to last day of current month + 1 year", async () => {
+                    it("should still set the expiry date to last day of current month + 1 year", () => {
                         const hgvTestResult = cloneDeep(testResultsMockDB[15]);
                         const pastExpiryDate = "2020-0";
                         hgvTestResult.testTypes[0].testTypeId = "94";
@@ -759,7 +759,6 @@ describe("TestResultsService calling generateExpiryDate", () => {
                           .then((hgvTestResultWithExpiryDate: any) => {
                               expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).toEqual(expectedExpiryDate.toISOString().split("T")[0]);
                           });
-
                     });
                 });
                 describe("First test types", () => {

--- a/tests/unit/generateExpiryDate.unitTest.ts
+++ b/tests/unit/generateExpiryDate.unitTest.ts
@@ -8,7 +8,6 @@ import {ITestResult} from "../../src/models/ITestResult";
 import testResults from "../resources/test-results.json";
 import moment from "moment";
 
-
 describe("TestResultsService calling generateExpiryDate", () => {
     let testResultsService: TestResultsService | any;
     let MockTestResultsDAO: jest.Mock;

--- a/tests/unit/generateExpiryDate.unitTest.ts
+++ b/tests/unit/generateExpiryDate.unitTest.ts
@@ -2,11 +2,12 @@ import {TestResultsService} from "../../src/services/TestResultsService";
 import fs from "fs";
 import path from "path";
 import {cloneDeep} from "lodash";
-import { COIF_EXPIRY_TEST_TYPES } from "../../src/assets/Enums";
+import { COIF_EXPIRY_TEST_TYPES, MESSAGES } from "../../src/assets/Enums";
 import dateMockUtils from "../util/dateMockUtils";
 import {ITestResult} from "../../src/models/ITestResult";
 import testResults from "../resources/test-results.json";
 import moment from "moment";
+import { HTTPError } from "../../src/models/HTTPError";
 
 describe("TestResultsService calling generateExpiryDate", () => {
     let testResultsService: TestResultsService | any;
@@ -549,7 +550,7 @@ describe("TestResultsService calling generateExpiryDate", () => {
             });
 
             describe("with only bad dates in the test history", () => {
-                it("should ignore the bad dates and set the expiry to 1 day short of a year from today", () => {
+                it("should throw error", async () => {
                     const psvTestResult = cloneDeep(testResultsMockDB[0]);
                     const getBySystemNumberResponse = cloneDeep(testResultsMockDB[0]) as ITestResult;
                     getBySystemNumberResponse.testTypes.forEach((test) => {
@@ -579,10 +580,12 @@ describe("TestResultsService calling generateExpiryDate", () => {
                     const expectedExpiryDate = new Date();
                     expectedExpiryDate.setFullYear(new Date().getFullYear() + 1);
                     expectedExpiryDate.setDate(new Date().getDate() - 1);
-                    return testResultsService.generateExpiryDate(psvTestResult)
-                      .then((psvTestResultWithExpiryDateAndTestNumber: any) => {
-                          expect((psvTestResultWithExpiryDateAndTestNumber.testTypes[0].testExpiryDate).split("T")[0]).toEqual(expectedExpiryDate.toISOString().split("T")[0]);
-                      });
+                    const expectedError = new HTTPError(500, MESSAGES.INTERNAL_SERVER_ERROR);
+                    try {
+                        await testResultsService.generateExpiryDate(psvTestResult);
+                    } catch (error) {
+                        expect(error).toEqual(expectedError);
+                    }
                 });
             });
             describe("with some bad dates in the test history, and an 'imminent' expiry date", () => {
@@ -725,7 +728,7 @@ describe("TestResultsService calling generateExpiryDate", () => {
                     });
                 });
                 describe("and the previous expiry date is malformed", () => {
-                    it("should still set the expiry date to last day of current month + 1 year", () => {
+                    it("should throw an error", async () => {
                         const hgvTestResult = cloneDeep(testResultsMockDB[15]);
                         const pastExpiryDate = "2020-0";
                         hgvTestResult.testTypes[0].testTypeId = "94";
@@ -753,11 +756,12 @@ describe("TestResultsService calling generateExpiryDate", () => {
                         });
                         testResultsService = new TestResultsService(new MockTestResultsDAO());
 
-                        const expectedExpiryDate = moment().add(1, "years").endOf("month").toDate();
-                        return testResultsService.generateExpiryDate(hgvTestResult)
-                          .then((hgvTestResultWithExpiryDate: any) => {
-                              expect((hgvTestResultWithExpiryDate.testTypes[0].testExpiryDate).split("T")[0]).toEqual(expectedExpiryDate.toISOString().split("T")[0]);
-                          });
+                        const expectedError = new HTTPError(500, MESSAGES.INTERNAL_SERVER_ERROR);
+                        try {
+                            await testResultsService.generateExpiryDate(hgvTestResult);
+                        } catch (error) {
+                            expect(error).toEqual(expectedError);
+                        }
                     });
                 });
                 describe("First test types", () => {


### PR DESCRIPTION
Changes to handle expiry date format for legacy data and to throw error if any other format of date occurs.

Original ticket - (changes on 18928 branch still)
https://jira.dvsacloud.uk/browse/CVSB-18928 
closed in favour of
https://jira.dvsacloud.uk/browse/CVSB-18931
