### PR TITLE
fix(19177): fix logs defect bug and reintroduce logDefectsReporting f…

### DIFF
--- a/src/handlers/expiry/providers/TestDataProvider.ts
+++ b/src/handlers/expiry/providers/TestDataProvider.ts
@@ -242,6 +242,7 @@ export class TestDataProvider implements ITestDataProvider {
     this.testResultsDAO = this.testResultsDAO as models.TestResultsDAO;
     try {
       const result = await this.testResultsDAO.createSingle(payload);
+      utils.LoggingUtil.logDefectsReporting(payload);
       return result.Attributes as models.ITestResult[];
     } catch (error) {
       console.error("TestDataProvider.insertTestResult -> ", error);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { MappingUtil } from "./mappingUtil";
 export { GetTestResults } from "../utils/GetTestResults";
 export { ValidationUtil } from "../utils/validationUtil";
+export { LoggingUtil } from "../utils/LoggingUtil";

--- a/tests/unit/LoggingUtil.unitTest.ts
+++ b/tests/unit/LoggingUtil.unitTest.ts
@@ -4,72 +4,72 @@ import { cloneDeep } from "lodash";
 import { TEST_STATUS, TEST_RESULT } from "../../src/assets/Enums";
 
 describe("Defects logging util", () => {
-    let testResult: any;
-    const consoleSpy = jest.spyOn(global.console, "info");
+  let testResult: any;
+  const consoleSpy = jest.spyOn(global.console, "info");
 
+  beforeEach(() => {
+    testResult = cloneDeep(testResults[1]);
+    jest.resetAllMocks();
+  });
 
-    beforeEach(() => {
-        testResult = cloneDeep(testResults[1]);
-        jest.resetAllMocks();
+  context("Having defects or advisories valid for logging", () => {
+    it("should log when the defects are valid", async () => {
+      testResult.testTypes[0].defects[0].deficiencyRef = "8.1.i";
+
+      const expectedLogObject = {
+        vin: testResult.vin,
+        vrm: testResult.vrm,
+        additionalNotesRecorded:
+          testResult.testTypes[0].additionalNotesRecorded,
+        deficiencyRef: testResult.testTypes[0].defects[0].deficiencyRef,
+        deficiencyCategory:
+          testResult.testTypes[0].defects[0].deficiencyCategory,
+        defectNotes:
+          testResult.testTypes[0].defects[0].additionalInformation.notes,
+        ...testResult.testTypes[0].defects[0].additionalInformation.location,
+      };
+
+      LoggingUtil.logDefectsReporting(testResult);
+
+      expect(consoleSpy).toBeCalledTimes(1);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Defects reporting: ",
+        expectedLogObject
+      );
     });
 
-    context("Having defects or advisories valid for logging", () => {
-        it("should log when the defects are valid", async () => {
-            testResult.testTypes[0].defects[0].deficiencyRef = "8.1.i";
+    it("should not log when the defects are valid but the test-result is cancelled", async () => {
+      testResult.testTypes[0].defects[0].deficiencyRef = "8.1.i";
+      testResult.testStatus = TEST_STATUS.CANCELLED;
 
-            const expectedLogObject = {vin: testResult.vin,
-                vrm: testResult.vrm,
-                additionalNotesRecorded: testResult.testTypes[0].additionalNotesRecorded,
-                deficiencyRef: testResult.testTypes[0].defects[0].deficiencyRef,
-                deficiencyCategory: testResult.testTypes[0].defects[0].deficiencyCategory,
-                defectNotes: testResult.testTypes[0].defects[0].additionalInformation.notes,
-                ...testResult.testTypes[0].defects[0].additionalInformation.location
-            };
+      LoggingUtil.logDefectsReporting(testResult);
 
-
-            LoggingUtil.logDefectsReporting(testResult);
-
-            expect(consoleSpy).toBeCalledTimes(1);
-            expect(consoleSpy).toHaveBeenCalledWith("Defects reporting: ", expectedLogObject);
-        });
-
-
-        it("should not log when the defects are valid but the test-result is cancelled", async () => {
-            testResult.testTypes[0].defects[0].deficiencyRef = "8.1.i";
-            testResult.testStatus = TEST_STATUS.CANCELLED;
-
-
-            LoggingUtil.logDefectsReporting(testResult);
-
-            expect(consoleSpy).toBeCalledTimes(0);
-        });
-
-        it("should not log when the defects are valid but the testType is abandoned", async () => {
-            testResult.testTypes[0].defects[0].deficiencyRef = "8.1.i";
-            testResult.testTypes[0].testResult = TEST_RESULT.ABANDONED;
-
-
-            LoggingUtil.logDefectsReporting(testResult);
-
-            expect(consoleSpy).toBeCalledTimes(0);
-        });
-
+      expect(consoleSpy).toBeCalledTimes(0);
     });
 
-    context("when there are no defects or deficiencies to be logged", () => {
-        it("should not call console.log when there are no valid defects", () => {
-            LoggingUtil.logDefectsReporting(testResult);
+    it("should not log when the defects are valid but the testType is abandoned", async () => {
+      testResult.testTypes[0].defects[0].deficiencyRef = "8.1.i";
+      testResult.testTypes[0].testResult = TEST_RESULT.ABANDONED;
 
-            expect(consoleSpy).toBeCalledTimes(0);
-        });
+      LoggingUtil.logDefectsReporting(testResult);
 
-        it("should not call console.log when defects array is empty", () => {
-            testResult.testTypes[0].defects  = [];
-
-            LoggingUtil.logDefectsReporting(testResult);
-
-            expect(consoleSpy).toBeCalledTimes(0);
-        });
-
+      expect(consoleSpy).toBeCalledTimes(0);
     });
+  });
+
+  context("when there are no defects or deficiencies to be logged", () => {
+    it("should not call console.log when there are no valid defects", () => {
+      LoggingUtil.logDefectsReporting(testResult);
+
+      expect(consoleSpy).toBeCalledTimes(0);
+    });
+
+    it("should not call console.log when defects array is empty", () => {
+      testResult.testTypes[0].defects = [];
+
+      LoggingUtil.logDefectsReporting(testResult);
+
+      expect(consoleSpy).toBeCalledTimes(0);
+    });
+  });
 });

--- a/tests/unit/expiry/TestDataProvider.unitTest.ts
+++ b/tests/unit/expiry/TestDataProvider.unitTest.ts
@@ -1,7 +1,9 @@
 import * as enums from "../../../src/assets/Enums";
+import * as models from "../../../src/models";
+import * as utils from "../../../src/utils";
+
 import { DateProvider } from "../../../src/handlers/expiry/providers/DateProvider";
 import { TestDataProvider } from "../../../src/handlers/expiry/providers/TestDataProvider";
-
 
 describe("TestDataProvider", () => {
   let testDataProvider: TestDataProvider;
@@ -17,109 +19,121 @@ describe("TestDataProvider", () => {
             return {
               getBySystemNumber: () => {
                 throw new Error("some error");
-              }
+              },
             };
           });
           testDataProvider.testResultsDAO = new MockTestResultsDAO();
           await testDataProvider.getTestHistory("123");
         } catch (error) {
           expect.assertions(1);
-          expect(error).toEqual( new Error("some error"));
+          expect(error).toEqual(new Error("some error"));
         }
       });
     });
     describe("when getBySystemNumber returns test results with invalid testEndTimestamp", () => {
       it("should return the filtered data", async () => {
-          testDataProvider = new TestDataProvider();
-          MockTestResultsDAO = jest.fn().mockImplementation(() => {
-            return {
-              getBySystemNumber: () => {
-                return {
-                  Count: 1,
-                  Items: [
-                    {
-                      testStartTimestamp: "2019-03-10T08:47:59.269Z",
-                      testEndTimestamp: "2019-03",
-                      testTypes: [
-                        { testCode: "fft1", testExpiryDate: "2019-02-10T08:47:59.261009Z" }
-                      ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
-                    }
-                  ]
-                };
-              }
-            };
-          });
-          expect.assertions(2);
-          testDataProvider.testResultsDAO = new MockTestResultsDAO();
-          const result = await testDataProvider.getTestHistory("123");
-          expect(result.length).toEqual(1);
-          expect(result[0].testEndTimestamp).toEqual("2019-03");
+        testDataProvider = new TestDataProvider();
+        MockTestResultsDAO = jest.fn().mockImplementation(() => {
+          return {
+            getBySystemNumber: () => {
+              return {
+                Count: 1,
+                Items: [
+                  {
+                    testStartTimestamp: "2019-03-10T08:47:59.269Z",
+                    testEndTimestamp: "2019-03",
+                    testTypes: [
+                      {
+                        testCode: "fft1",
+                        testExpiryDate: "2019-02-10T08:47:59.261009Z",
+                      },
+                    ],
+                    testStatus: enums.TEST_STATUS.SUBMITTED,
+                  },
+                ],
+              };
+            },
+          };
+        });
+        expect.assertions(2);
+        testDataProvider.testResultsDAO = new MockTestResultsDAO();
+        const result = await testDataProvider.getTestHistory("123");
+        expect(result.length).toEqual(1);
+        expect(result[0].testEndTimestamp).toEqual("2019-03");
       });
     });
     describe("when getBySystemNumber returns invalid testStartTimestamp", () => {
       it("should return the filtered data", async () => {
-          testDataProvider = new TestDataProvider();
-          MockTestResultsDAO = jest.fn().mockImplementation(() => {
-            return {
-              getBySystemNumber: () => {
-                return {
-                  Count: 1,
-                  Items: [
-                    {
-                      testStartTimestamp: "2019-03",
-                      testEndTimestamp: "2019-03-10T08:47:59.269Z",
-                      testTypes: [
-                        { testCode: "fft1", testExpiryDate: "2019-02-10T08:47:59.261009Z" }
-                      ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
-                    }
-                  ]
-                };
-              }
-            };
-          });
-          expect.assertions(2);
-          testDataProvider.testResultsDAO = new MockTestResultsDAO();
-          const result = await testDataProvider.getTestHistory("123");
-          expect(result.length).toEqual(1);
-          expect(result[0].testStartTimestamp).toEqual("2019-03");
+        testDataProvider = new TestDataProvider();
+        MockTestResultsDAO = jest.fn().mockImplementation(() => {
+          return {
+            getBySystemNumber: () => {
+              return {
+                Count: 1,
+                Items: [
+                  {
+                    testStartTimestamp: "2019-03",
+                    testEndTimestamp: "2019-03-10T08:47:59.269Z",
+                    testTypes: [
+                      {
+                        testCode: "fft1",
+                        testExpiryDate: "2019-02-10T08:47:59.261009Z",
+                      },
+                    ],
+                    testStatus: enums.TEST_STATUS.SUBMITTED,
+                  },
+                ],
+              };
+            },
+          };
+        });
+        expect.assertions(2);
+        testDataProvider.testResultsDAO = new MockTestResultsDAO();
+        const result = await testDataProvider.getTestHistory("123");
+        expect(result.length).toEqual(1);
+        expect(result[0].testStartTimestamp).toEqual("2019-03");
       });
     });
     describe("when getBySystemNumber returns array of valid data", () => {
       it("should return the filtered data", async () => {
-          expect.assertions(1);
-          testDataProvider = new TestDataProvider();
-          MockTestResultsDAO = jest.fn().mockImplementation(() => {
-            return {
-              getBySystemNumber: () => {
-                return {
-                  Count: 2,
-                  Items: [
-                    {
-                      testStartTimestamp: "2019-03-10T08:47:59.269Z",
-                      testEndTimestamp: "2019-03-10T09:30:59.269Z",
-                      testTypes: [
-                        { testCode: "fft1", testExpiryDate: "2019-02-10T08:47:59.261Z" }
-                      ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
-                    },
-                    {
-                      testStartTimestamp: "2019-01-10T08:47:59.269000Z",
-                      testEndTimestamp: "2019-01-10T09:30:59.269000Z",
-                      testTypes: [
-                        { testCode: "rpt1", testExpiryDate: "2020-12-10T08:47:59.269000Z" }
-                      ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
-                    }
-                  ]
-                };
-              }
-            };
-          });
-          testDataProvider.testResultsDAO = new MockTestResultsDAO();
-          const result  = await testDataProvider.getTestHistory("123");
-          expect(result.length).toEqual(2);
+        expect.assertions(1);
+        testDataProvider = new TestDataProvider();
+        MockTestResultsDAO = jest.fn().mockImplementation(() => {
+          return {
+            getBySystemNumber: () => {
+              return {
+                Count: 2,
+                Items: [
+                  {
+                    testStartTimestamp: "2019-03-10T08:47:59.269Z",
+                    testEndTimestamp: "2019-03-10T09:30:59.269Z",
+                    testTypes: [
+                      {
+                        testCode: "fft1",
+                        testExpiryDate: "2019-02-10T08:47:59.261Z",
+                      },
+                    ],
+                    testStatus: enums.TEST_STATUS.SUBMITTED,
+                  },
+                  {
+                    testStartTimestamp: "2019-01-10T08:47:59.269000Z",
+                    testEndTimestamp: "2019-01-10T09:30:59.269000Z",
+                    testTypes: [
+                      {
+                        testCode: "rpt1",
+                        testExpiryDate: "2020-12-10T08:47:59.269000Z",
+                      },
+                    ],
+                    testStatus: enums.TEST_STATUS.SUBMITTED,
+                  },
+                ],
+              };
+            },
+          };
+        });
+        testDataProvider.testResultsDAO = new MockTestResultsDAO();
+        const result = await testDataProvider.getTestHistory("123");
+        expect(result.length).toEqual(2);
       });
     });
   });
@@ -133,7 +147,7 @@ describe("TestDataProvider", () => {
             return {
               getBySystemNumber: () => {
                 throw new Error("some error");
-              }
+              },
             };
           });
           testDataProvider.testResultsDAO = new MockTestResultsDAO();
@@ -154,10 +168,10 @@ describe("TestDataProvider", () => {
                 return {
                   testStartTimestamp: "2019-10-10T08:47:59.269Z",
                   testEndTimestamp: "2019-10-10T09:30:59.269Z",
-                  testTypes: [{ testCode: "aat1", testExpiryDate: "2020-01" }]
+                  testTypes: [{ testCode: "aat1", testExpiryDate: "2020-01" }],
                 };
               }
-            }
+            },
           };
         });
         testDataProvider.testResultsDAO = new MockTestResultsDAO();
@@ -180,30 +194,30 @@ describe("TestDataProvider", () => {
                       testStartTimestamp: "2019-02-10T08:47:59.269Z",
                       testEndTimestamp: "2019-02-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "aat1", testExpiryDate: "2020-01-05" }
+                        { testCode: "aat1", testExpiryDate: "2020-01-05" },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
                     },
                     {
                       testStartTimestamp: "2019-03-10T08:47:59.269Z",
                       testEndTimestamp: "2019-03-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "fft1", testExpiryDate: "2020-02-15" }
+                        { testCode: "fft1", testExpiryDate: "2020-02-15" },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
                     },
                     {
                       testStartTimestamp: "2019-01-10T08:47:59.269Z",
                       testEndTimestamp: "2019-01-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "rpt1", testExpiryDate: "2020-01-04" }
+                        { testCode: "rpt1", testExpiryDate: "2020-01-04" },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
-                    }
-                  ]
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
+                    },
+                  ],
                 };
               }
-            }
+            },
           };
         });
         testDataProvider.testResultsDAO = new MockTestResultsDAO();
@@ -227,38 +241,38 @@ describe("TestDataProvider", () => {
                       testStartTimestamp: "2019-02-10T08:47:59.269Z",
                       testEndTimestamp: "2019-02-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "aat1", testExpiryDate: "2020-01-05" }
+                        { testCode: "aat1", testExpiryDate: "2020-01-05" },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
                     },
                     {
                       testStartTimestamp: "2019-03-10T08:47:59.269Z",
                       testEndTimestamp: "2019-03-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "fft1", testExpiryDate: "2020-02-15" }
+                        { testCode: "fft1", testExpiryDate: "2020-02-15" },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
                     },
                     {
                       testStartTimestamp: "2019-03-10T08:47:59.269Z",
                       testEndTimestamp: "2019-03-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "fft1", testExpiryDate: undefined }
+                        { testCode: "fft1", testExpiryDate: undefined },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
                     },
                     {
                       testStartTimestamp: "2019-01-10T08:47:59.269Z",
                       testEndTimestamp: "2019-01-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "rpt1", testExpiryDate: "2020-01" }
+                        { testCode: "rpt1", testExpiryDate: "2020-01" },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
-                    }
-                  ]
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
+                    },
+                  ],
                 };
               }
-            }
+            },
           };
         });
         testDataProvider.testResultsDAO = new MockTestResultsDAO();
@@ -282,30 +296,39 @@ describe("TestDataProvider", () => {
                       testStartTimestamp: "2019-02-10T08:47:59.269Z",
                       testEndTimestamp: "2019-02-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "aat1", testExpiryDate: "2018-02-10T08:47:59.269Z" }
+                        {
+                          testCode: "aat1",
+                          testExpiryDate: "2018-02-10T08:47:59.269Z",
+                        },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
                     },
                     {
                       testStartTimestamp: "2019-03-10T08:47:59.269Z",
                       testEndTimestamp: "2019-03-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "fft1", testExpiryDate: "2019-02-10T08:47:59.261009Z" }
+                        {
+                          testCode: "fft1",
+                          testExpiryDate: "2019-02-10T08:47:59.261009Z",
+                        },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
                     },
                     {
                       testStartTimestamp: "2019-01-10T08:47:59.269Z",
                       testEndTimestamp: "2019-01-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "rpt1", testExpiryDate: "2020-12-10T08:47:59.129000Z" }
+                        {
+                          testCode: "rpt1",
+                          testExpiryDate: "2020-12-10T08:47:59.129000Z",
+                        },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
-                    }
-                  ]
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
+                    },
+                  ],
                 };
               }
-            }
+            },
           };
         });
         expect.assertions(1);
@@ -330,30 +353,39 @@ describe("TestDataProvider", () => {
                       testStartTimestamp: "2019-02-10T08:47:59.269Z",
                       testEndTimestamp: "2019-02-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "aat1", testExpiryDate: "2018-02-10T08:47:59.269Z" }
+                        {
+                          testCode: "aat1",
+                          testExpiryDate: "2018-02-10T08:47:59.269Z",
+                        },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
                     },
                     {
                       testStartTimestamp: "2019-03-10T08:47:59.269Z",
                       testEndTimestamp: "2019-03-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "fft1", testExpiryDate: "2019-02-10T08:47:59.261Z" }
+                        {
+                          testCode: "fft1",
+                          testExpiryDate: "2019-02-10T08:47:59.261Z",
+                        },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
                     },
                     {
                       testStartTimestamp: "2019-01-10T08:47:59.269Z",
                       testEndTimestamp: "2019-01-10T09:30:59.269Z",
                       testTypes: [
-                        { testCode: "rpt1", testExpiryDate: "2020-12-10T08:47:59.129Z" }
+                        {
+                          testCode: "rpt1",
+                          testExpiryDate: "2020-12-10T08:47:59.129Z",
+                        },
                       ],
-                      testStatus: enums.TEST_STATUS.SUBMITTED
-                    }
-                  ]
+                      testStatus: enums.TEST_STATUS.SUBMITTED,
+                    },
+                  ],
                 };
               }
-            }
+            },
           };
         });
         expect.assertions(1);
@@ -362,6 +394,45 @@ describe("TestDataProvider", () => {
         const expectedDate = new Date("2020-12-10T08:47:59.129000Z");
         expect(expiry).toEqual(expectedDate);
       });
+    });
+  });
+  context("for insertTestResult", () => {
+    it(`should call the 'testResultDAO.createSingle' method and 'logDefectsReporting'`, async () => {
+      testDataProvider = new TestDataProvider();
+      MockTestResultsDAO = jest.fn().mockImplementation(() => {
+        return {
+          createSingle: (something: any) => {
+            return Promise.resolve({});
+          },
+        };
+      });
+      testDataProvider.testResultsDAO = new MockTestResultsDAO();
+      const logDefectsReportingSpy = spyOn(
+        utils.LoggingUtil,
+        "logDefectsReporting"
+      );
+      expect(logDefectsReportingSpy).not.toHaveBeenCalled();
+      await testDataProvider.insertTestResult({} as models.ITestResultPayload);
+      expect(logDefectsReportingSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw the error once it fails", async () => {
+      testDataProvider = new TestDataProvider();
+      const errorMsg = "boom";
+      MockTestResultsDAO = jest.fn().mockImplementation(() => {
+        return {
+          createSingle: (something: any) => Promise.reject(errorMsg),
+        };
+      });
+
+      testDataProvider.testResultsDAO = new MockTestResultsDAO();
+      try {
+        await testDataProvider.insertTestResult(
+          {} as models.ITestResultPayload
+        );
+      } catch (e) {
+        expect(e).toBe(errorMsg);
+      }
     });
   });
 });


### PR DESCRIPTION
- Add util function back that logs defects as per AC into test-results logs CW services
- Add additional unit test that checks whether the util function is called after inserting record (TestDataProvider)

*CW Query*
defect:
```sh
fields @timestamp, vin, vrm, additionalNotesRecorded, deficiencyRef, deficiencyCategory, defectNotes, horizontal, lateral, axleNumber
| sort @timestamp desc 
| filter @message like 'Defects reporting: ' and deficiencyCategory != 'advisory'
```

advisory:
```sh
fields @timestamp, vin, vrm, additionalNotesRecorded, deficiencyRef, deficiencyCategory, defectNotes
| sort @timestamp desc 
| filter @message like 'Defects reporting: ' and deficiencyCategory == 'advisory'
```