### PR TITLE
feat(VTA-122): change to joi validation

### DIFF
--- a/src/models/validators/SpecialistTestsCommonSchemaCancelled.ts
+++ b/src/models/validators/SpecialistTestsCommonSchemaCancelled.ts
@@ -6,7 +6,7 @@ export const defectsCommonSchemaSpecialistTestsCancelled = defectsCommonSchema.k
         location: Joi.object().keys({
             vertical: Joi.any().only(["upper", "lower"]).required().allow(null),
             horizontal: Joi.any().only(["inner", "outer"]).required().allow(null),
-            lateral: Joi.any().only(["nearside", "centre", "offside"]).required().allow(null),
+            lateral: Joi.any().only(["nearside", "centre", "offside", "rear"]).required().allow(null),
             longitudinal: Joi.any().only(["front", "rear"]).required().allow(null),
             rowNumber: Joi.number().max(20).required().allow(null),
             seatNumber: Joi.number().max(6).required().allow(null),

--- a/src/models/validators/SpecialistTestsCommonSchemaSubmitted.ts
+++ b/src/models/validators/SpecialistTestsCommonSchemaSubmitted.ts
@@ -6,7 +6,7 @@ export const defectsCommonSchemaSpecialistTestsSubmitted = defectsCommonSchema.k
         location: Joi.object().keys({
             vertical: Joi.any().only(["upper", "lower"]).required().allow(null),
             horizontal: Joi.any().only(["inner", "outer"]).required().allow(null),
-            lateral: Joi.any().only(["nearside", "centre", "offside"]).required().allow(null),
+            lateral: Joi.any().only(["nearside", "centre", "offside", "rear"]).required().allow(null),
             longitudinal: Joi.any().only(["front", "rear"]).required().allow(null),
             rowNumber: Joi.number().max(20).required().allow(null),
             seatNumber: Joi.number().max(6).required().allow(null),

--- a/src/models/validators/TestResultsSchemaHGVCancelled.ts
+++ b/src/models/validators/TestResultsSchemaHGVCancelled.ts
@@ -6,7 +6,7 @@ const defectsSchema = defectsCommonSchema.keys({
         location: Joi.object().keys({
             vertical: Joi.any().only(["upper", "lower"]).required().allow(null),
             horizontal: Joi.any().only(["inner", "outer"]).required().allow(null),
-            lateral: Joi.any().only(["nearside", "centre", "offside"]).required().allow(null),
+            lateral: Joi.any().only(["nearside", "centre", "offside", "rear"]).required().allow(null),
             longitudinal: Joi.any().only(["front", "rear"]).required().allow(null),
             rowNumber: Joi.number().max(20).required().allow(null),
             seatNumber: Joi.number().max(6).required().allow(null),

--- a/src/models/validators/TestResultsSchemaHGVSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaHGVSubmitted.ts
@@ -6,7 +6,7 @@ const defectsSchema = defectsCommonSchema.keys({
         location: Joi.object().keys({
             vertical: Joi.any().only(["upper", "lower"]).required().allow(null),
             horizontal: Joi.any().only(["inner", "outer"]).required().allow(null),
-            lateral: Joi.any().only(["nearside", "centre", "offside"]).required().allow(null),
+            lateral: Joi.any().only(["nearside", "centre", "offside", "rear"]).required().allow(null),
             longitudinal: Joi.any().only(["front", "rear"]).required().allow(null),
             rowNumber: Joi.number().max(20).required().allow(null),
             seatNumber: Joi.number().max(6).required().allow(null),

--- a/src/models/validators/TestResultsSchemaPSVCancelled.ts
+++ b/src/models/validators/TestResultsSchemaPSVCancelled.ts
@@ -6,7 +6,7 @@ const defectsSchema = defectsCommonSchema.keys({
         location: Joi.object().keys({
             vertical: Joi.any().only(["upper", "lower"]).required().allow(null),
             horizontal: Joi.any().only(["inner", "outer"]).required().allow(null),
-            lateral: Joi.any().only(["nearside", "centre", "offside"]).required().allow(null),
+            lateral: Joi.any().only(["nearside", "centre", "offside", "rear"]).required().allow(null),
             longitudinal: Joi.any().only(["front", "rear"]).required().allow(null),
             rowNumber: Joi.number().max(20).required().allow(null),
             seatNumber: Joi.number().max(6).required().allow(null),

--- a/src/models/validators/TestResultsSchemaPSVSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaPSVSubmitted.ts
@@ -6,7 +6,7 @@ const defectsSchema = defectsCommonSchema.keys({
         location: Joi.object().keys({
             vertical: Joi.any().only(["upper", "lower"]).required().allow(null),
             horizontal: Joi.any().only(["inner", "outer"]).required().allow(null),
-            lateral: Joi.any().only(["nearside", "centre", "offside"]).required().allow(null),
+            lateral: Joi.any().only(["nearside", "centre", "offside", "rear"]).required().allow(null),
             longitudinal: Joi.any().only(["front", "rear"]).required().allow(null),
             rowNumber: Joi.number().max(20).required().allow(null),
             seatNumber: Joi.number().max(6).required().allow(null),

--- a/src/models/validators/TestResultsSchemaTRLCancelled.ts
+++ b/src/models/validators/TestResultsSchemaTRLCancelled.ts
@@ -6,7 +6,7 @@ const defectsSchema = defectsCommonSchema.keys({
         location: Joi.object().keys({
             vertical: Joi.any().only(["upper", "lower"]).required().allow(null),
             horizontal: Joi.any().only(["inner", "outer"]).required().allow(null),
-            lateral: Joi.any().only(["nearside", "centre", "offside"]).required().allow(null),
+            lateral: Joi.any().only(["nearside", "centre", "offside", "rear"]).required().allow(null),
             longitudinal: Joi.any().only(["front", "rear"]).required().allow(null),
             rowNumber: Joi.number().max(20).required().allow(null),
             seatNumber: Joi.number().max(6).required().allow(null),

--- a/src/models/validators/TestResultsSchemaTRLSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaTRLSubmitted.ts
@@ -6,7 +6,7 @@ const defectsSchema = defectsCommonSchema.keys({
         location: Joi.object().keys({
             vertical: Joi.any().only(["upper", "lower"]).required().allow(null),
             horizontal: Joi.any().only(["inner", "outer"]).required().allow(null),
-            lateral: Joi.any().only(["nearside", "centre", "offside"]).required().allow(null),
+            lateral: Joi.any().only(["nearside", "centre", "offside", "rear"]).required().allow(null),
             longitudinal: Joi.any().only(["front", "rear"]).required().allow(null),
             rowNumber: Joi.number().max(20).required().allow(null),
             seatNumber: Joi.number().max(6).required().allow(null),

--- a/src/models/validators/test-types/testTypesSchemaPut.ts
+++ b/src/models/validators/test-types/testTypesSchemaPut.ts
@@ -5,7 +5,7 @@ const additionalInformationSchema = Joi.object().keys({
   location: Joi.object().keys({
     vertical: Joi.any().only(["upper", "lower"]).allow(null),
     horizontal: Joi.any().only(["inner", "outer"]).allow(null),
-    lateral: Joi.any().only(["nearside", "centre", "offside"]).allow(null),
+    lateral: Joi.any().only(["nearside", "centre", "offside", "rear"]).allow(null),
     longitudinal: Joi.any().only(["front", "rear"]).allow(null),
     rowNumber: Joi.number().max(20).allow(null),
     seatNumber: Joi.number().max(6).allow(null),


### PR DESCRIPTION
## include rear as an additional option when failing a defect

This change has been made so that the test results service is able to accomodate for lateral rear being an acceptable value. Before this change an error in the joi validation was produced, due to rear not being included in the acceptable values array.
[link to ticket number](https://dvsa.atlassian.net/browse/VTA-122)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
