### PR TITLE
VTA-737: Allow POTF testStationTypes to be used when starting visit in VTA

### DIFF
--- a/docs/test-results-api.yml
+++ b/docs/test-results-api.yml
@@ -264,6 +264,7 @@ components:
             - atf
             - gvts
             - hq
+            - potf
         testerName:
           type: string
           maxLength: 60

--- a/src/models/validators/CommonSchema.ts
+++ b/src/models/validators/CommonSchema.ts
@@ -54,7 +54,7 @@ export const testResultsCommonSchema = Joi.object().keys({
     vin: Joi.string().min(1).max(21).required(),
     testStationName: Joi.string().max(999).required().allow(""),
     testStationPNumber: Joi.string().max(20).required().allow(""),
-    testStationType: Joi.any().only(["atf", "gvts", "hq"]).required(),
+    testStationType: Joi.any().only(["atf", "gvts", "hq", "potf"]).required(),
     testerName: Joi.string().max(60).required().allow(""),
     testerEmailAddress: Joi.string().max(60).required().allow(""),
     testerStaffId: Joi.string().max(36).required().allow(""),


### PR DESCRIPTION
## Allow POTF testStationTypes to be used when starting visit in VTA

Update the service to allow potf testStationType to be used when posting a test result.
[https://dvsa.atlassian.net/browse/VTA-737](VTA-737)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
