### PR TITLE
chore(cb2-4674): update put test result api definition

### DIFF
--- a/docs/test-results-api.yml
+++ b/docs/test-results-api.yml
@@ -40,37 +40,6 @@ paths:
           description: Unauthorised Access
         '404':
           description: Operation not supported
-  '/test-results/{testResultId}':
-    put:
-      summary: 'Update a test result, for a particular testResultId'
-      tags:
-        - updateTestResults
-      parameters:
-        - in: path
-          name: testResultId
-          schema:
-            type: string
-          required: true
-      requestBody:
-        description: The test result to be updated
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/completeTestResults'
-      responses:
-        '200':
-          description: The updated test-result
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/testResults'
-        '401':
-          description: Not authenticated
-        '403':
-          description: Unauthorised Access
-        '404':
-          description: Operation not supported
   '/test-results/archive/{testResultId}':
     put:
       summary: 'Archive a specific test-type, for a particular testResultId'
@@ -150,7 +119,8 @@ paths:
               - current
               - archived
               - all
-          description: Query param to filter the test-results based on testVersion. If not present then GET will return the current test-result.
+          description:
+            Query param to filter the test-results based on testVersion. If not present then GET will return the current test-result.
             Can be used only with testResultId query param, otherwise it is not taken into account.
       responses:
         '200':
@@ -159,6 +129,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/testResults'
+        '401':
+          description: Not authenticated
+        '403':
+          description: Unauthorised Access
+        '404':
+          description: Operation not supported
+    put:
+      summary: 'Update a test result using the systemNumber and testResultId as unique identifiers.'
+      tags:
+        - updateTestResults
+      parameters:
+        - in: path
+          name: systemNumber
+          schema:
+            type: string
+          required: true
+      requestBody:
+        description: The test result to be updated
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/completeTestResults'
+      responses:
+        '200':
+          description: The updated test-result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/completeTestResults'
         '401':
           description: Not authenticated
         '403':

--- a/docs/test-results-api.yml
+++ b/docs/test-results-api.yml
@@ -159,6 +159,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/completeTestResults'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+               $ref: '#/components/schemas/putBadRequest'
         '401':
           description: Not authenticated
         '403':
@@ -733,6 +739,15 @@ components:
           type: string
           maxLength: 200
           nullable: true
+    putBadRequest:
+      type: object
+      properties:
+        errors:
+          $ref: '#/components/schemas/validationErrors'
+    validationErrors:
+      type: array
+      items:
+        type: string
 security:
   - OAuth2:
       - read


### PR DESCRIPTION
## Update the Swagger documentation to match the fixes made

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-4674)

 - PUT returns a TestResult on success - Swagger says it just returns a 200
 - Path param for the PUT is actually systemNumber not testResultId

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
