### PR TITLE
feat(cb2-4939): reverting changes to testtypeid and testerstaffid

### DIFF
--- a/src/models/validators/CommonSchema.ts
+++ b/src/models/validators/CommonSchema.ts
@@ -18,7 +18,7 @@ export const defectsCommonSchema = Joi.object().keys({
 export const testTypesCommonSchema = Joi.object().keys({
     name: Joi.string().required(),
     testTypeName: Joi.string().required().allow("", null),
-    testTypeId: Joi.string().required().allow("", null),
+    testTypeId: Joi.string().required().allow(""),
     testTypeStartTimestamp: Joi.date().iso().required(),
     certificateNumber: Joi.string().required().allow("", null),
     prohibitionIssued: Joi.boolean().required().allow(null),
@@ -57,7 +57,7 @@ export const testResultsCommonSchema = Joi.object().keys({
     testStationType: Joi.any().only(["atf", "gvts", "hq", "potf"]).required(),
     testerName: Joi.string().max(60).required().allow("", null),
     testerEmailAddress: Joi.string().max(60).required().allow("", null),
-    testerStaffId: Joi.string().max(36).required().allow("", null),
+    testerStaffId: Joi.string().max(36).required().allow(""),
     testStartTimestamp: Joi.date().iso().required(),
     testEndTimestamp: Joi.date().iso().required(),
     testStatus: Joi.any().only(["submitted", "cancelled"]).required(),


### PR DESCRIPTION
Reverting validation changes to testTypeId and testerStaffId to disallow null in order to bring in line with regression pack tests.

[cb2-4934](https://dvsa.atlassian.net/browse/CB2-4934)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
