### PR TITLE
feat(cb2-5532): ability to handle linked tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This code repository uses [serverless framework](https://www.serverless.com/fram
 You will also require to install dynamodb serverless to run your project with by running the following command `npm run tools-setup` in your preferred shell.
 Once dynamoDB is installed, you will need a local serverless profile to be created so that you can start developping locally.
 The profiles are stored under `~/.aws/credentials`.
+
 ```sh
 # ~/.aws/credentials
 
@@ -48,6 +49,7 @@ aws_access_key_id=<yourDummyAccesskey>
 aws_secret_access_key=<yourDummySecret>
 
 ```
+
 Please refer to the local development section to [configure your project locally](#developing-locally).
 
 ### Environmental variables
@@ -153,6 +155,10 @@ For the CI/CD and automation please refer to the following pages for further det
 
 - [Development process](https://wiki.dvsacloud.uk/display/HVT/CVS+Pipeline+Infrastructure)
 - [Pipeline](https://wiki.dvsacloud.uk/pages/viewpage.action?pageId=36870584)
+
+## Note on the `PUT` endpoint
+
+If the record being amended only contains one item in the `testTypes` array, the default behaviour is to map the test types in the database which were not amended back onto the record. This behaviour was introduced as part of https://github.com/dvsa/cvs-svc-test-results/pull/268.
 
 ## Contributing
 

--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -278,10 +278,10 @@ export class VehicleTestController implements IVehicleTestController {
     newTestResult.testVersion = enums.TEST_VERSION.CURRENT;
     if (payload.testTypes.length === 1) {
       const { testNumber } = payload.testTypes[0];
-      const testTypes = newTestResult.testTypes.filter(
+      const testTypesNotInPayload = newTestResult.testTypes.filter(
         (testType) => testType.testNumber !== testNumber
       );
-      payload.testTypes = testTypes.length ? [...payload.testTypes, ...testTypes] : payload.testTypes
+      payload.testTypes = testTypesNotInPayload.length ? [...payload.testTypes, ...testTypesNotInPayload] : payload.testTypes
     }
     mergeWith(newTestResult, payload, utils.MappingUtil.arrayCustomizer);
     // @ts-ignore

--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -276,6 +276,13 @@ export class VehicleTestController implements IVehicleTestController {
     const newTestResult = cloneDeep(oldTestResult);
     oldTestResult.testVersion = enums.TEST_VERSION.ARCHIVED;
     newTestResult.testVersion = enums.TEST_VERSION.CURRENT;
+    if (payload.testTypes.length === 1) {
+      const { testNumber } = payload.testTypes[0];
+      const testTypes = newTestResult.testTypes.filter(
+        (testType) => testType.testNumber !== testNumber
+      );
+      payload.testTypes = testTypes.length ? [...payload.testTypes, ...testTypes] : payload.testTypes
+    }
     mergeWith(newTestResult, payload, utils.MappingUtil.arrayCustomizer);
     // @ts-ignore
     newTestResult.testTypes = await this.generateNewTestCode(

--- a/tests/unit/updateTestResults.unitTest.ts
+++ b/tests/unit/updateTestResults.unitTest.ts
@@ -78,6 +78,150 @@ describe("updateTestResults", () => {
               );
             });
         });
+        it("should add the old test types onto the new test type if there is only one testType", async () => {
+          const testResultMockDBWithUniqueTestNumbers = cloneDeep(testResultsMockDB[0])
+          testResultMockDBWithUniqueTestNumbers.testTypes[2].testNumber = "3"
+          MockTestResultsDAO = jest.fn().mockImplementation(() => {
+            return {
+              updateTestResult: () => {
+                return Promise.resolve({});
+              },
+              getActivity: () => {
+                return Promise.resolve([
+                  {
+                    startTime: "2018-03-22",
+                    endTime: "2021-04-22",
+                  },
+                ]);
+              },
+              getBySystemNumber: () =>
+                Promise.resolve(Array.of(testResultMockDBWithUniqueTestNumbers)),
+              getTestCodesAndClassificationFromTestTypes: () => {
+                return Promise.resolve({
+                  defaultTestCode: "bde",
+                  testTypeClassification: "Annual With Certificate",
+                  name: "foo",
+                  testTypeName: "bar"
+                });
+              },
+            };
+          });
+
+          const testDataProvider = new TestDataProvider();
+          testDataProvider.testResultsDAO = new MockTestResultsDAO();
+          const vehicleTestController = new VehicleTestController(
+            testDataProvider,
+            new DateProvider()
+          );
+
+          const updatedPayload: any = cloneDeep(testResultMockDBWithUniqueTestNumbers);
+          expect(updatedPayload.testTypes.length).toBe(3)
+          updatedPayload.testTypes = updatedPayload.testTypes.slice(0, 1)
+          expect(updatedPayload.testTypes.length).toBe(1)
+          const returnedRecord =
+            await vehicleTestController.mapOldTestResultToNew(
+              updatedPayload.systemNumber,
+              updatedPayload,
+              msUserDetails
+            );
+          expect(returnedRecord).not.toEqual(undefined);
+          expect(returnedRecord).not.toEqual({});
+          expect(returnedRecord.testTypes.length).toBe(3)
+        });
+
+        it("should not add any test types onto the new test type if there is only one testType in payload and DB", async () => {
+          MockTestResultsDAO = jest.fn().mockImplementation(() => {
+            return {
+              updateTestResult: () => {
+                return Promise.resolve({});
+              },
+              getActivity: () => {
+                return Promise.resolve([
+                  {
+                    startTime: "2018-03-22",
+                    endTime: "2021-04-22",
+                  },
+                ]);
+              },
+              getBySystemNumber: () =>
+                Promise.resolve(Array.of(cloneDeep(testResultsMockDB[30]))),
+              getTestCodesAndClassificationFromTestTypes: () => {
+                return Promise.resolve({
+                  defaultTestCode: "bde",
+                  testTypeClassification: "Annual With Certificate",
+                  name: "foo",
+                  testTypeName: "bar"
+                });
+              },
+            };
+          });
+
+          const testDataProvider = new TestDataProvider();
+          testDataProvider.testResultsDAO = new MockTestResultsDAO();
+          const vehicleTestController = new VehicleTestController(
+            testDataProvider,
+            new DateProvider()
+          );
+
+          const updatedPayload: any = cloneDeep(testResultsMockDB[30]);
+          expect(updatedPayload.testTypes.length).toBe(1)
+          const returnedRecord =
+            await vehicleTestController.mapOldTestResultToNew(
+              updatedPayload.systemNumber,
+              updatedPayload,
+              msUserDetails
+            );
+          expect(returnedRecord).not.toEqual(undefined);
+          expect(returnedRecord).not.toEqual({});
+          expect(returnedRecord.testTypes.length).toBe(1)
+        });
+
+        it("should add the old test types onto the new test type if there is only one testType", async () => {
+          MockTestResultsDAO = jest.fn().mockImplementation(() => {
+            return {
+              updateTestResult: () => {
+                return Promise.resolve({});
+              },
+              getActivity: () => {
+                return Promise.resolve([
+                  {
+                    startTime: "2018-03-22",
+                    endTime: "2021-04-22",
+                  },
+                ]);
+              },
+              getBySystemNumber: () =>
+                Promise.resolve(Array.of(cloneDeep(testResultsMockDB[0]))),
+              getTestCodesAndClassificationFromTestTypes: () => {
+                return Promise.resolve({
+                  defaultTestCode: "bde",
+                  testTypeClassification: "Annual With Certificate",
+                  name: "foo",
+                  testTypeName: "bar"
+                });
+              },
+            };
+          });
+
+          const testDataProvider = new TestDataProvider();
+          testDataProvider.testResultsDAO = new MockTestResultsDAO();
+          const vehicleTestController = new VehicleTestController(
+            testDataProvider,
+            new DateProvider()
+          );
+
+          const updatedPayload: any = cloneDeep(testResultsMockDB[0]);
+          expect(updatedPayload.testTypes.length).toBe(3)
+          const returnedRecord =
+            await vehicleTestController.mapOldTestResultToNew(
+              updatedPayload.systemNumber,
+              updatedPayload,
+              msUserDetails
+            );
+          expect(returnedRecord).not.toEqual(undefined);
+          expect(returnedRecord).not.toEqual({});
+          expect(returnedRecord.testTypes.length).toBe(3)
+        });
 
         context("when changing an attribute that requires new testCode", () => {
           context("when changing an attribute on the test-type", () => {


### PR DESCRIPTION
## Handle linked tests

There is a requirement to handle linked tests independently. Because of the discrepancy with the validation between the `POST` and the `PUT` endpoint, this solution seems to be the cleanest way of updating ONLY one test without updating other linked tests. It effectively flattens test records as far as the `PUT` endpoint and VTM (amend) are concerned. If the endpoint receives only one test type, then it adds in the old test types that it got from the database. Tested manually in feature branch and works as intended.

There is no requirement currently to update more than one linked test in the same `PUT` request in VTM. Even if there was, with the change only adding extra linked tests to the test coming in if there is only one linked test, this would still be possible.

This solution only affects the `PUT` endpoint, which only VTM uses at the moment, however it could have an impact on potential future consumers of the endpoint.

This solution could warrant a confluence page to explain why this was necessary for MVP, without carrying out significant backend and/or frontend changes, just so that decision is tracked somewhere.

From running the regression packs against the feature branch this change should have a limited to no impact on regression packs, although current failures in the regression packs make this statement hard to confirm at the time of writing this.
[CB2-5532](https://dvsa.atlassian.net/browse/CB2-5532)

[FEATURE_TEST_BACKEND (FULL)](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2431/) for these changes

[FEATURE_TEST_BACKEND (EXPIRY_DATES)](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2440/DVSA_20CVS_20Backend_20Automation/)

There seems have been some broken/failing tests on feature branches for some time now. The same failures crop up [here](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2428/DVSA_20CVS_20Backend_20Automation/) for example.

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
