### PR TITLE
VTA-866: fix broken unit tests

### DIFF
--- a/tests/unit/generateExpiryDate.unitTest.ts
+++ b/tests/unit/generateExpiryDate.unitTest.ts
@@ -415,6 +415,7 @@ describe("VehicleTestController calling generateExpiryDate", () => {
                 describe("with good regn/first use date strings", () => {
                     it("should set the expiry date to last day of current month + 1 year", () => {
                         const hgvTestResult = cloneDeep(testResultsMockDB[15]);
+                        hgvTestResult.regnDate = "2020-10-10";
                         hgvTestResult.testTypes[0].testTypeId = "94";
                         MockTestResultsDAO = jest.fn().mockImplementation(() => {
                             return {
@@ -508,6 +509,7 @@ describe("VehicleTestController calling generateExpiryDate", () => {
                 describe("and the previous expiry date is malformed", () => {
                     it("should still set the expiry date to last day of current month + 1 year", () => {
                         const hgvTestResult = cloneDeep(testResultsMockDB[15]);
+                        hgvTestResult.regnDate = "2020-10-10";
                         const pastExpiryDate = "2020-0";
                         hgvTestResult.testTypes[0].testTypeId = "94";
                         const testResultExpiredCertificateWithSameSystemNumber = cloneDeep(testResultsMockDB[15]);


### PR DESCRIPTION
## VTA-866 - Fix Broken Unit Tests

Registration Anniversary date of test record (15) being used in failing tests is 31/10/2022, tests have been failing since 31/08/2022 as we are now within 2 months of that date which is throwing off the logic in strategy.getExpiryDate method. 

This fix corrects the regnDate of the test record being used in the failing tests. 
(The test record itself has not been modified as it is used by a number of other tests)

[VTA-866](https://dvsa.atlassian.net/browse/VTA-866)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
