### PR TITLE
feat(cb2-6380): remove activity check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5997,9 +5997,9 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base": {
       "version": "0.11.2",
@@ -7064,7 +7064,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "configstore": {
       "version": "4.0.0",
@@ -14386,9 +14386,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -14573,6 +14573,15 @@
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "mkdirp": {

--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -282,7 +282,7 @@ export class VehicleTestController implements IVehicleTestController {
       oldTestResult,
       newTestResult
     );
-    await this.checkTestTypeStartAndEndTimestamp(oldTestResult, newTestResult);
+    await this.checkTestTypeStartAndEndTimestamp(newTestResult);
     utils.MappingUtil.cleanDefectsArrayForSpecialistTests(newTestResult);
     utils.MappingUtil.setAuditDetails(
       newTestResult,
@@ -365,84 +365,20 @@ export class VehicleTestController implements IVehicleTestController {
   }
 
   public async checkTestTypeStartAndEndTimestamp(
-    oldTestResult: models.ITestResult,
     newTestResult: models.ITestResult
   ) {
     const { testTypes } = newTestResult;
-    const { testStartTimestamp, testerStaffId, testStationPNumber } =
-      oldTestResult;
-    const params = {
-      fromStartTime: DateProvider.getStartOfDay(testStartTimestamp),
-      toStartTime: testStartTimestamp,
-      activityType: "visit",
-      testStationPNumber,
-      testerStaffId,
-    };
-    try {
-      const activities: [{ startTime: Date; endTime: Date }] =
-        await this.dataProvider.getActivity(params);
-      if (activities.length > 1) {
-        throw new models.HTTPError(500, enums.ERRORS.NoUniqueActivityFound);
-      }
-      const activity = activities[0];
-      const { startTime, endTime } = activity;
-      const isStartTimeInvalid = testTypes.some((testType) => {
-        const { testTypeStartTimestamp } = testType;
-        console.log("testTypeStartTimestamp", testTypeStartTimestamp);
-        return DateProvider.isOutsideTimePeriod(
-          testTypeStartTimestamp,
-          endTime,
-          startTime
-        );
-      });
-      if (isStartTimeInvalid) {
-        throw new models.HTTPError(
-          400,
-          VehicleTestController.mapTimestampError(
-            "testTypeStartTimestamp",
-            startTime,
-            endTime
-          )
-        );
-      }
-      const isEndTimeInvalid = testTypes.some((testType) => {
-        const { testTypeEndTimestamp } = testType;
-        console.log("testTypeEndTimestamp", testTypeEndTimestamp);
-        return DateProvider.isOutsideTimePeriod(
-          testTypeEndTimestamp,
-          endTime,
-          startTime
-        );
-      });
-      if (isEndTimeInvalid) {
-        throw new models.HTTPError(
-          400,
-          VehicleTestController.mapTimestampError(
-            "testTypeEndTimestamp",
-            startTime,
-            endTime
-          )
-        );
-      }
-      const isStartAfterEnd = testTypes.some((testType) => {
-        const { testTypeStartTimestamp, testTypeEndTimestamp } = testType;
-        return DateProvider.isAfterDate(
-          testTypeStartTimestamp,
-          testTypeEndTimestamp
-        );
-      });
-      if (isStartAfterEnd) {
-        throw new models.HTTPError(400, enums.ERRORS.StartTimeBeforeEndTime);
-      }
-    } catch (err) {
-      console.error(
-        "VehicleTestController -> checkTestTypeStartAndEndTimestamp",
-        err
+    const isStartAfterEnd = testTypes.some((testType) => {
+      const { testTypeStartTimestamp, testTypeEndTimestamp } = testType;
+      return DateProvider.isAfterDate(
+        testTypeStartTimestamp,
+        testTypeEndTimestamp
       );
-      if (err.statusCode !== 404) {
-        throw new models.HTTPError(err.statusCode, err.body);
-      }
+    });
+    if (isStartAfterEnd) {
+      throw new models.HTTPError(400, enums.ERRORS.StartTimeBeforeEndTime);
     }
+
   }
 
   private static getTestResultToArchive(
@@ -461,13 +397,6 @@ export class VehicleTestController implements IVehicleTestController {
     return testResults[0];
   }
 
-  private static mapTimestampError(
-    timeStampKey: string,
-    startTime: Date,
-    endTime: Date
-  ) {
-    return `The ${timeStampKey} must be within the visit, between ${startTime} and ${endTime}`;
-  }
   private static shouldGenerateCertificateNumber(
     testType: models.TestType,
     vehicleType: string

--- a/src/handlers/expiry/providers/TestDataProvider.ts
+++ b/src/handlers/expiry/providers/TestDataProvider.ts
@@ -258,10 +258,6 @@ export class TestDataProvider implements ITestDataProvider {
       throw error;
     }
   }
-
-  public async getActivity(params: models.ActivityParams) {
-    return this.testResultsDAO?.getActivity(params);
-  }
   //#endregion
   //#region [rgba(0, 205, 30, 0.1)] Private Static functions
   private static filterTestResultsByParam(

--- a/src/models/TestResultsDAO.ts
+++ b/src/models/TestResultsDAO.ts
@@ -236,51 +236,6 @@ export class TestResultsDAO {
     // });
   }
 
-  public getActivity(filters: {
-    fromStartTime: string | Date;
-    toStartTime: string | Date;
-    activityType: string;
-    testStationPNumber: string;
-    testerStaffId: string;
-  }): any {
-    const event = {
-      path: "/activities/details",
-      queryStringParameters: {
-        fromStartTime: filters.fromStartTime,
-        toStartTime: filters.toStartTime,
-        activityType: filters.activityType,
-        testStationPNumber: filters.testStationPNumber,
-        testerStaffId: filters.testerStaffId,
-      },
-      httpMethod: "GET",
-      resource: "/activities/details",
-    };
-
-    return LambdaService.invoke(
-      TestResultsDAO.lambdaInvokeEndpoints.functions.getActivity.name,
-      event
-    );
-    // TODO Add Mocks - CVSB-19153
-    // return [
-    //   {
-    //     testerStaffId: "62ef-ccd-4f-9-b72",
-    //     testerName: "mail@mail.com",
-    //     testStationName: "Name",
-    //     activityDay: "2021-02-22",
-    //     parentId: "db1c62a8-43c3-469e-ae9a-19a43583d127",
-    //     testStationPNumber: "09-4129632",
-    //     testStationType: "gvts",
-    //     startTime: new Date(Date.now() - 1000000).toISOString(),
-    //     activityType: "unaccountable time",
-    //     // endTime: new Date(Date.now() + 1000000).toISOString(),
-    //     endTime: null,
-    //     waitReason: [],
-    //     notes: null,
-    //     testStationEmail: "mail@mail.com",
-    //     id: "d015f-c4646-49877-bc559-11d0f6dd8",
-    //   },
-    // ];
-  }
 
   public updateTestResult(
     updatedTestResult: models.ITestResult

--- a/tests/unit/updateTestResults.unitTest.ts
+++ b/tests/unit/updateTestResults.unitTest.ts
@@ -197,184 +197,12 @@ describe("updateTestResults", () => {
         });
 
         context("and when changing testTypeStartTimestamp", () => {
-          const errorMessageEndTime =
-            "The testTypeEndTimestamp must be within the visit, between 2021-01-14T10:36:33.987Z and 2021-01-14T20:00:33.987Z";
-          const errorMessageStartTime =
-            "The testTypeStartTimestamp must be within the visit, between 2021-01-14T10:36:33.987Z and 2021-01-14T20:00:33.987Z";
-          context(
-            "and the testTypeStartTimestamp is before the visit startTime",
-            () => {
-              it("should return error 400 testTypeStartTimestamp must be within the visit", () => {
-                MockTestResultsDAO = jest.fn().mockImplementation(() => {
-                  return {
-                    getActivity: () => {
-                      return Promise.resolve([
-                        {
-                          startTime: "2021-01-14T10:36:33.987Z",
-                          endTime: "2021-01-14T20:00:33.987Z",
-                        },
-                      ]);
-                    },
-                    getBySystemNumber: () => {
-                      return Promise.resolve(Array.of(cloneDeep(testToUpdate)));
-                    },
-                  };
-                });
-                testResultsService = new TestResultsService(
-                  new MockTestResultsDAO()
-                );
-                testToUpdate.testTypes[0].testTypeStartTimestamp =
-                  "2021-01-13T08:36:33.987Z";
-                expect.assertions(3);
-                return testResultsService
-                  .updateTestResult(
-                    testToUpdate.systemNumber,
-                    testToUpdate,
-                    msUserDetails
-                  )
-                  .catch((errorResponse: { statusCode: any; body: any }) => {
-                    expect(errorResponse).toBeInstanceOf(HTTPError);
-                    expect(errorResponse.statusCode).toEqual(400);
-                    expect(errorResponse.body).toEqual(errorMessageStartTime);
-                  });
-              });
-            }
-          );
-
-          context(
-            "and the testTypeStartTimestamp is after the visit endTime",
-            () => {
-              it("should return error 400 testTypeStartTimestamp must be within the visit", () => {
-                MockTestResultsDAO = jest.fn().mockImplementation(() => {
-                  return {
-                    getActivity: () => {
-                      return Promise.resolve([
-                        {
-                          startTime: "2021-01-14T10:36:33.987Z",
-                          endTime: "2021-01-14T20:00:33.987Z",
-                        },
-                      ]);
-                    },
-                    getBySystemNumber: () => {
-                      return Promise.resolve(Array.of(cloneDeep(testToUpdate)));
-                    },
-                  };
-                });
-                testResultsService = new TestResultsService(
-                  new MockTestResultsDAO()
-                );
-                testToUpdate.testTypes[0].testTypeStartTimestamp =
-                  "2021-01-14T21:00:33.987Z";
-                expect.assertions(3);
-                return testResultsService
-                  .updateTestResult(
-                    testToUpdate.systemNumber,
-                    testToUpdate,
-                    msUserDetails
-                  )
-                  .catch((errorResponse: { statusCode: any; body: any }) => {
-                    expect(errorResponse).toBeInstanceOf(HTTPError);
-                    expect(errorResponse.statusCode).toEqual(400);
-                    expect(errorResponse.body).toEqual(errorMessageStartTime);
-                  });
-              });
-            }
-          );
-
-          context(
-            "and the testTypeEndTimestamp is before the visit startTime",
-            () => {
-              it("should return error 400 testTypeStartTimestamp must be within the visit", () => {
-                MockTestResultsDAO = jest.fn().mockImplementation(() => {
-                  return {
-                    getActivity: () => {
-                      return Promise.resolve([
-                        {
-                          startTime: "2021-01-14T10:36:33.987Z",
-                          endTime: "2021-01-14T20:00:33.987Z",
-                        },
-                      ]);
-                    },
-                    getBySystemNumber: () => {
-                      return Promise.resolve(Array.of(cloneDeep(testToUpdate)));
-                    },
-                  };
-                });
-                testResultsService = new TestResultsService(
-                  new MockTestResultsDAO()
-                );
-                testToUpdate.testTypes[0].testTypeEndTimestamp =
-                  "2021-01-13T18:00:33.987Z";
-                expect.assertions(3);
-                return testResultsService
-                  .updateTestResult(
-                    testToUpdate.systemNumber,
-                    testToUpdate,
-                    msUserDetails
-                  )
-                  .catch((errorResponse: { statusCode: any; body: any }) => {
-                    expect(errorResponse).toBeInstanceOf(HTTPError);
-                    expect(errorResponse.statusCode).toEqual(400);
-                    expect(errorResponse.body).toEqual(errorMessageEndTime);
-                  });
-              });
-            }
-          );
-
-          context(
-            "and the testTypeEndTimestamp is after the visit endTime",
-            () => {
-              it("should return error 400 testTypeStartTimestamp must be within the visit", () => {
-                MockTestResultsDAO = jest.fn().mockImplementation(() => {
-                  return {
-                    getActivity: () => {
-                      return Promise.resolve([
-                        {
-                          startTime: "2021-01-14T10:36:33.987Z",
-                          endTime: "2021-01-14T20:00:33.987Z",
-                        },
-                      ]);
-                    },
-                    getBySystemNumber: () => {
-                      return Promise.resolve(Array.of(cloneDeep(testToUpdate)));
-                    },
-                  };
-                });
-                testResultsService = new TestResultsService(
-                  new MockTestResultsDAO()
-                );
-                testToUpdate.testTypes[0].testTypeEndTimestamp =
-                  "2021-01-15T18:00:33.987Z";
-                expect.assertions(3);
-                return testResultsService
-                  .updateTestResult(
-                    testToUpdate.systemNumber,
-                    testToUpdate,
-                    msUserDetails
-                  )
-                  .catch((errorResponse: { statusCode: any; body: any }) => {
-                    expect(errorResponse).toBeInstanceOf(HTTPError);
-                    expect(errorResponse.statusCode).toEqual(400);
-                    expect(errorResponse.body).toEqual(errorMessageEndTime);
-                  });
-              });
-            }
-          );
-
           context(
             "and the testTypeStartTimestamp is after the testTypeStartTimestamp",
             () => {
               it("should return error 400 testTypeStartTimestamp must be before testTypeEndTimestamp", () => {
                 MockTestResultsDAO = jest.fn().mockImplementation(() => {
                   return {
-                    getActivity: () => {
-                      return Promise.resolve([
-                        {
-                          startTime: "2021-01-14T10:36:33.987Z",
-                          endTime: "2021-01-14T20:00:33.987Z",
-                        },
-                      ]);
-                    },
                     getBySystemNumber: () => {
                       return Promise.resolve(Array.of(cloneDeep(testToUpdate)));
                     },
@@ -404,81 +232,6 @@ describe("updateTestResults", () => {
               });
             }
           );
-
-          context(
-            "and the getActivity function returns more than one activity",
-            () => {
-              it("should return error 500 No unique activity found", () => {
-                MockTestResultsDAO = jest.fn().mockImplementation(() => {
-                  return {
-                    getActivity: () => {
-                      return Promise.resolve([
-                        "firstActivity",
-                        "secondActivity",
-                      ]);
-                    },
-                    getBySystemNumber: () => {
-                      return Promise.resolve(Array.of(cloneDeep(testToUpdate)));
-                    },
-                  };
-                });
-                testResultsService = new TestResultsService(
-                  new MockTestResultsDAO()
-                );
-                expect.assertions(3);
-                return testResultsService
-                  .updateTestResult(
-                    testToUpdate.systemNumber,
-                    testToUpdate,
-                    msUserDetails
-                  )
-                  .catch((errorResponse: { statusCode: any; body: any }) => {
-                    expect(errorResponse).toBeInstanceOf(HTTPError);
-                    expect(errorResponse.statusCode).toEqual(500);
-                    expect(errorResponse.body).toEqual(
-                      ERRORS.NoUniqueActivityFound
-                    );
-                  });
-              });
-            }
-          );
-
-          context(
-            "and the getActivity function throws an error different from 404",
-            () => {
-              it("should return Error Activities microservice error", () => {
-                MockTestResultsDAO = jest.fn().mockImplementation(() => {
-                  return {
-                    getActivity: () => {
-                      return Promise.reject({
-                        statusCode: 400,
-                        body: ERRORS.EventIsEmpty,
-                      });
-                    },
-                    getBySystemNumber: () => {
-                      return Promise.resolve(Array.of(cloneDeep(testToUpdate)));
-                    },
-                  };
-                });
-                testResultsService = new TestResultsService(
-                  new MockTestResultsDAO()
-                );
-                expect.assertions(3);
-                return testResultsService
-                  .updateTestResult(
-                    testToUpdate.systemNumber,
-                    testToUpdate,
-                    msUserDetails
-                  )
-                  .catch((errorResponse: { statusCode: any; body: any }) => {
-                    expect(errorResponse).toBeInstanceOf(HTTPError);
-                    expect(errorResponse.statusCode).toEqual(400);
-                    expect(errorResponse.body).toEqual(ERRORS.EventIsEmpty);
-                  });
-              });
-            }
-          );
-
           context(
             "and the getActivity function throws a 404 Not Found error",
             () => {
@@ -540,6 +293,7 @@ describe("updateTestResults", () => {
               });
             }
           );
+
         });
       });
 


### PR DESCRIPTION
## Ignoring Activity Check for Amend / PUT TestResult

There currently exists some validation of Test Results which looks for a single Activity for the date, tester and test station of the Test.  If it finds more than one Activity it returns an error and the Test cannot be amended. PO has confirmed that it is possible that there could be more than one Activity for a date, tester and station.

- bump `minimatch` to stop the husky hooks failing

[Jenkins regression pack test](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2432/DVSA_20CVS_20Backend_20Automation/) on feature branch.

[CB2-6380](https://dvsa.atlassian.net/browse/CB2-6380)

## Checklist

- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number
