### PR TITLE
feat(cb2-6287): added support for trl free loaded retest to group 10

### DIFF
--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -262,7 +262,7 @@ export const TEST_TYPES_GROUP7: string[] = [
 
 // tests for HGV and TRL - Annual tests, First tests, Annual retests, Paid/Part paid prohibition clearance
 export const TEST_TYPES_GROUP9_10: string[] = [
-  "76", "95", "94", "53", "54", "65", "66", "70", "79", "82", "83", "41", "40", "98", "99", "103", "104", "67", "107", "113", "116", "119", "120"
+  "76", "95", "94", "53", "54", "65", "66", "70", "79", "82", "83", "41", "40", "98", "99", "103", "104", "67", "107", "113", "116", "119", "120", "199"
 ];
 
 // tests for TRL - Paid/Part paid prohibition clearance(retest, full inspection, part inspection, without cert)


### PR DESCRIPTION
## Amend a TRL Free Loaded Retest in Group 10

TRL Free Loaded Retests were missing from the Amend groups. This is to put them back in so we can support amending them on VTM. 

[Link to Jenkins Report](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/lastSuccessfulBuild/DVSA_20CVS_20Backend_20Automation/)

The only failing/errored tests are unrelated to this ticket as they do not refer to test type ID 199.

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6287)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [X] Squashed commit contains the JIRA ticket number
