### PR TITLE
VTA-903: Capture LEC Certificate Number

### DIFF
--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -9,6 +9,7 @@ export enum ERRORS {
     WrongVehicleTypeOnLEC = "Wrong vehicle type for conducting a LEC test",
     NoCertificateNumberOnAdr = "Certificate number not present on ADR test type",
     NoCertificateNumberOnTir = "Certificate number not present on TIR test type",
+    NoCertificateNumberOnLec = "Certificate number not present on LEC test type",
     NoExpiryDate = "Expiry date not present on ADR test type",
     IncorrectTestStatus = '"testStatus" should be one of ["submitted", "cancelled"]',
     PayloadCannotBeEmpty = "Payload cannot be empty",

--- a/src/utils/validationUtil.ts
+++ b/src/utils/validationUtil.ts
@@ -77,6 +77,9 @@ export class ValidationUtil {
     if (ValidationUtil.isPassAdrTestTypeWithoutExpiryDate(payload)) {
       throw new models.HTTPError(400, enums.ERRORS.NoExpiryDate);
     }
+    if (ValidationUtil.isFailLecTestTypeWithoutCertificateNumber(payload)) {
+      throw new models.HTTPError(400, enums.ERRORS.NoCertificateNumberOnLec);
+    }
 
     const missingMandatoryTestResultFields: string[] = ValidationUtil.validateMandatoryTestResultFields(
       payload
@@ -222,6 +225,7 @@ private static validateDates(
       .forEach((testType) => {
         const {
           testExpiryDate,
+          certificateNumber,
           modType,
           emissionStandard,
           fuelType,
@@ -229,6 +233,9 @@ private static validateDates(
         } = testType;
         if (!testExpiryDate) {
           missingFields.push(enums.ERRORS.NoLECExpiryDate);
+        }
+        if (!certificateNumber) {
+          missingFields.push(enums.ERRORS.NoCertificateNumberOnLec);
         }
         if (!modType) {
           missingFields.push(enums.ERRORS.NoModificationType);
@@ -388,6 +395,21 @@ private static validateDates(
             ValidationUtil.isTestTypeAdr(testType) &&
             testType.testResult === enums.TEST_RESULT.PASS &&
             !testType.testExpiryDate &&
+            testStatus === enums.TEST_STATUS.SUBMITTED
+        )
+      : false;
+  }
+
+  private static isFailLecTestTypeWithoutCertificateNumber(
+    payload: models.ITestResultPayload
+  ): boolean {
+    const { testTypes, testStatus } = payload;
+    return testTypes
+      ? testTypes.some(
+          (testType) =>
+            ValidationUtil.isTestTypeLec(testType) &&
+            testType.testResult === enums.TEST_RESULT.FAIL &&
+            !testType.certificateNumber &&
             testStatus === enums.TEST_STATUS.SUBMITTED
         )
       : false;


### PR DESCRIPTION
## Capture LEC test certificate number in VTA so that it aligns with ADR tests

Updated the logic/validation to ensure that certificate number / expiry date are provided for LEC test types when expected, as per story.
[VTA-903](https://dvsa.atlassian.net/browse/VTA-903)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
