### PR TITLE
feature(cb2-6092): customise emissions section

### DIFF
--- a/src/models/validators/CommonSchema.ts
+++ b/src/models/validators/CommonSchema.ts
@@ -20,7 +20,12 @@ export const testTypesCommonSchema = Joi.object().keys({
     testTypeName: Joi.string().required().allow("", null),
     testTypeId: Joi.string().required().allow(""),
     testTypeStartTimestamp: Joi.date().iso().required(),
-    certificateNumber: Joi.string().required().allow("", null),
+    certificateNumber:   Joi.string().when("testResult", {
+        is: "pass",
+        then: Joi.string().required().allow("", null),
+        otherwise: Joi.string().optional().allow("", null),
+    }).allow(null),
+    
     prohibitionIssued: Joi.boolean().required().allow(null),
     reasonForAbandoning: Joi.string().required().allow("", null),
     additionalNotesRecorded: Joi.string().max(500).required().allow("", null),

--- a/src/models/validators/CommonSchema.ts
+++ b/src/models/validators/CommonSchema.ts
@@ -20,12 +20,7 @@ export const testTypesCommonSchema = Joi.object().keys({
     testTypeName: Joi.string().required().allow("", null),
     testTypeId: Joi.string().required().allow(""),
     testTypeStartTimestamp: Joi.date().iso().required(),
-    certificateNumber:   Joi.string().when("testResult", {
-        is: "pass",
-        then: Joi.string().required().allow("", null),
-        otherwise: Joi.string().optional().allow("", null),
-    }).allow(null),
-    
+    certificateNumber: Joi.string().required().allow("", null),
     prohibitionIssued: Joi.boolean().required().allow(null),
     reasonForAbandoning: Joi.string().required().allow("", null),
     additionalNotesRecorded: Joi.string().max(500).required().allow("", null),

--- a/src/models/validators/test-types/testTypesSchemaSpecialistTestsPut.ts
+++ b/src/models/validators/test-types/testTypesSchemaSpecialistTestsPut.ts
@@ -29,18 +29,39 @@ export const testTypesCommonSchemaSpecialistTests = Joi.object().keys({
 }).required();
 
 export const testTypesSpecialistGroup1 = testTypesCommonSchemaSpecialistTests.keys({
-  certificateNumber: Joi.string().required()
+  certificateNumber: Joi.string().when("$hasTestResult", {
+    is: "pass",
+    then:  Joi.string().required(),
+    otherwise: Joi.string().optional().allow("", null)
+  }),
 });
 
 export const testTypesSpecialistGroup2 = testTypesCommonSchemaSpecialistTests.keys({
-  certificateNumber: Joi.string().required(),
+
+  certificateNumber: Joi.string().when("$hasTestResult", {
+    is: "pass",
+    then:  Joi.string().required(),
+    otherwise: Joi.string().optional().allow("", null)
+  }),
+
   secondaryCertificateNumber: Joi.string().when("$hasTestResult", {
     is: "pass",
     then:  Joi.string().alphanum().max(20).required(),
     otherwise: Joi.string().allow("", null)
   }),
-  testExpiryDate: Joi.date().iso().required(),
-  testAnniversaryDate: Joi.date().iso().required(),
+
+  testExpiryDate: Joi.date().when("$hasTestResult", {
+    is: "pass",
+    then:  Joi.date().iso().required(),
+    otherwise: Joi.date().iso().optional().allow("", null)
+  }),
+
+  testAnniversaryDate: Joi.date().when("$hasTestResult", {
+    is: "pass",
+    then:  Joi.date().iso().required(),
+    otherwise: Joi.date().iso().optional().allow("", null)
+  }),
+
   numberOfSeatbeltsFitted: Joi.number().required().allow(null),
   lastSeatbeltInstallationCheckDate: Joi.date().required().allow(null),
   seatbeltInstallationCheckDate: Joi.boolean().required().allow(null),

--- a/tests/resources/test-results-post.json
+++ b/tests/resources/test-results-post.json
@@ -1019,5 +1019,68 @@
         "defects": []
       }
     ]
+  },
+  {
+    "vin": "1B7GG36N12S678410",
+    "vrm": "BQ91YHQ",
+    "countryOfRegistration": "gb",
+    "euVehicleCategory": "m2",
+    "odometerReading": 22222,
+    "odometerReadingUnits": "kilometres",
+    "preparerName": null,
+    "preparerId": "No preparer ID given",
+    "createdAt": "2022-11-11T00:52:16.000",
+    "testStartTimestamp": "2022-11-11T00:51:39.000",
+    "testTypes": [
+        {
+            "testResult": "fail",
+            "reasonForAbandoning": null,
+            "additionalCommentsForAbandon": null,
+            "testTypeName": "COIF retest with annual test",
+            "secondaryCertificateNumber": null,
+            "testTypeStartTimestamp": "2022-11-11T00:51:39.000",
+            "testTypeEndTimestamp": "2022-11-11T00:52:15.000",
+            "prohibitionIssued": false,
+            "seatbeltInstallationCheckDate": true,
+            "numberOfSeatbeltsFitted": 8,
+            "lastSeatbeltInstallationCheckDate": "2022-10-10T00:00:00.000",
+            "additionalNotesRecorded": null,
+            "testTypeId": "175",
+            "name": "Specialist test",
+            "customDefects": [
+                {
+                    "referenceNumber": "ref",
+                    "defectName": "name",
+                    "defectNotes": "notes"
+                }
+            ],
+            "defects": []
+        }
+    ],
+    "testStationName": "Abshire-Kub",
+    "testStationPNumber": "09-4129632",
+    "testStationType": "gvts",
+    "testerStaffId": "10000009",
+    "testerName": "CVS Automation9",
+    "testerEmailAddress": "CVS.Automation9@dvsatest-cloud.uk",
+    "reasonForCreation": "reasonb",
+    "testResultId": "7c968a55-5da5-414d-863a-ba5997a327fc",
+    "vehicleType": "psv",
+    "testStatus": "submitted",
+    "systemNumber": "11000002",
+    "testEndTimestamp": "2022-11-11T00:52:14.616Z",
+    "vehicleClass": {
+        "code": "s",
+        "description": "small psv (ie: less than or equal to 22 seats)"
+    },
+    "noOfAxles": 2,
+    "numberOfWheelsDriven": null,
+    "regnDate": "2011-01-05",
+    "createdByName": "CVS Automation9",
+    "createdById": "10000009",
+    "numberOfSeats": 50,
+    "vehicleConfiguration": "rigid",
+    "vehicleSize": "small",
+    "reasonForCancellation": null
   }
 ]

--- a/tests/resources/test-results-post.json
+++ b/tests/resources/test-results-post.json
@@ -1047,6 +1047,7 @@
             "additionalNotesRecorded": null,
             "testTypeId": "175",
             "name": "Specialist test",
+            "certificateNumber": null,
             "customDefects": [
                 {
                     "referenceNumber": "ref",

--- a/tests/resources/test-results.json
+++ b/tests/resources/test-results.json
@@ -5934,5 +5934,72 @@
     "vehicleSize": "large",
     "vehicleType": "psv",
     "vrm": "Y926OJL"
+  },
+  {
+    "vin": "1B7GG36N12S678410",
+    "vrm": "BQ91YHQ",
+    "countryOfRegistration": "gb",
+    "euVehicleCategory": "m2",
+    "odometerReading": 22222,
+    "odometerReadingUnits": "kilometres",
+    "preparerName": null,
+    "preparerId": "No preparer ID given",
+    "createdAt": "2022-11-11T00:52:16.000",
+    "testStartTimestamp": "2022-11-11T00:51:39.000",
+    "testTypes": [
+        {
+            "testCode": "cks",
+            "testResult": "fail",
+            "reasonForAbandoning": null,
+            "additionalCommentsForAbandon": null,
+            "testTypeName": "COIF retest with annual test",
+            "secondaryCertificateNumber": null,
+            "testNumber": "W01A92749",
+            "testTypeStartTimestamp": "2022-11-11T00:51:39.000",
+            "testTypeEndTimestamp": "2022-11-11T00:52:15.000",
+            "prohibitionIssued": false,
+            "seatbeltInstallationCheckDate": true,
+            "numberOfSeatbeltsFitted": 8,
+            "lastSeatbeltInstallationCheckDate": "2022-10-10T00:00:00.000",
+            "additionalNotesRecorded": null,
+            "testTypeId": "175",
+            "name": "Specialist test",
+            "createdAt": "2022-11-11T00:52:16.203Z",
+            "lastUpdatedAt": "2022-11-11T00:52:16.203Z",
+            "testTypeClassification": "Annual With Certificate",
+            "customDefects": [
+                {
+                    "referenceNumber": "ref",
+                    "defectName": "name",
+                    "defectNotes": "notes"
+                }
+            ]
+        }
+    ],
+    "testStationName": "Abshire-Kub",
+    "testStationPNumber": "09-4129632",
+    "testStationType": "gvts",
+    "testerStaffId": "10000009",
+    "testerName": "CVS Automation9",
+    "testerEmailAddress": "CVS.Automation9@dvsatest-cloud.uk",
+    "reasonForCreation": "reasonb",
+    "testResultId": "7c968a55-5da5-414d-863a-ba5997a327fc",
+    "vehicleType": "psv",
+    "testStatus": "submitted",
+    "systemNumber": "11000002",
+    "testEndTimestamp": "2022-11-11T00:52:14.616Z",
+    "vehicleClass": {
+        "code": "s",
+        "description": "small psv (ie: less than or equal to 22 seats)"
+    },
+    "noOfAxles": 2,
+    "numberOfWheelsDriven": null,
+    "regnDate": "2011-01-05",
+    "createdByName": "CVS Automation9",
+    "createdById": "10000009",
+    "numberOfSeats": 50,
+    "vehicleConfiguration": "rigid",
+    "vehicleSize": "small",
+    "reasonForCancellation": null
   }
 ]

--- a/tests/resources/test-results.json
+++ b/tests/resources/test-results.json
@@ -5967,6 +5967,7 @@
             "createdAt": "2022-11-11T00:52:16.203Z",
             "lastUpdatedAt": "2022-11-11T00:52:16.203Z",
             "testTypeClassification": "Annual With Certificate",
+            "certificateNumber": null,
             "customDefects": [
                 {
                     "referenceNumber": "ref",

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3480,4 +3480,15 @@ describe("insertTestResult", () => {
     }
   );
 
+  context(
+    "when inserting a 'fail' Specialist test with blank certificate number",
+    () => {
+      it("should not throw an error", () => {
+        const testResult = testResultsPostMock[13];
+        expect.assertions(1);
+        expect(ValidationUtil.validateInsertTestResultPayload(testResult)).toBe(true);
+      });
+    }
+  );
+
 });

--- a/tests/unit/updateTestResults.unitTest.ts
+++ b/tests/unit/updateTestResults.unitTest.ts
@@ -796,4 +796,48 @@ describe("updateTestResults", () => {
       });
     });
   });
+
+  context("when testing specialist test", () => {
+    context(
+      "when updating a 'fail' specialist test with blank certificate number",
+      () => {
+        it("should not return an error", () => {
+          MockTestResultsDAO = jest.fn().mockImplementation(() => {
+            return {
+              updateTestResult: () => {
+                return Promise.resolve({});
+              },
+              getActivity: () => {
+                return Promise.resolve([
+                  {
+                    startTime: "2018-03-22",
+                    endTime: "2022-10-20",
+                  },
+                ]);
+              },
+              getBySystemNumber: () =>
+                Promise.resolve(Array.of(cloneDeep(testToUpdate))),
+            };
+          });
+
+          testResultsService = new TestResultsService(
+            new MockTestResultsDAO()
+          );
+          testToUpdate = cloneDeep(testResultsMockDB[64]);
+          expect.assertions(2);
+          return testResultsService
+            .updateTestResult(
+              testToUpdate.systemNumber,
+              testToUpdate,
+              msUserDetails
+            )
+           .then((returnedRecord: any) => {
+              expect(returnedRecord).not.toEqual(undefined);
+              expect(returnedRecord).not.toEqual({});
+            });
+        });
+      }
+    );
+
+  });
 });


### PR DESCRIPTION
## Customise Emissions section / certificate fields based on test result

Changes to allow Specialist tests to be created/updated when certificate number/expiry date/anniversary date are hidden

Regression pack run:
https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2497/

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6092)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
