### PR TITLE
task(cb2-6894): desk assessment created by

### DIFF
--- a/src/utils/mappingUtil.ts
+++ b/src/utils/mappingUtil.ts
@@ -41,36 +41,34 @@ export class MappingUtil {
       } as models.ITestResultFilters;
     }
     const {
-      toDateTime,
-      fromDateTime,
-      status,
-      testResultId,
-      version,
-      testStationPNumber,
-    } = event.queryStringParameters;
+        toDateTime,
+        fromDateTime,
+        status,
+        testResultId,
+        version,
+        testStationPNumber
+      } = event.queryStringParameters;
     if (toDateTime === "" || fromDateTime === "") {
-      const errorDate = toDateTime === "" ? "toDate" : "fromDate";
-      if (subSegment) {
-        subSegment.addError(`Bad Request - ${errorDate} empty`);
+        const errorDate = toDateTime === "" ? "toDate" : "fromDate";
+        if (subSegment) {
+          subSegment.addError(`Bad Request - ${errorDate} empty`);
+        }
+        console.error(
+          `Bad Request in getTestResultsBySystemNumber - ${errorDate} empty`
+        );
+        throw new HTTPError(400, enums.MESSAGES.BAD_REQUEST);
       }
-      console.error(
-        `Bad Request in getTestResultsBySystemNumber - ${errorDate} empty`
-      );
-      throw new HTTPError(400, enums.MESSAGES.BAD_REQUEST);
-    }
     toDate = toDateTime ? new Date(toDateTime) : toDate;
-    fromDate = fromDateTime
-      ? new Date(fromDateTime)
-      : DateProvider.getTwoYearsFromDate(toDate);
+    fromDate = fromDateTime ? new Date(fromDateTime) :  DateProvider.getTwoYearsFromDate(toDate);
     if (status) {
-      testStatus = status;
-    }
+        testStatus = status;
+      }
     if (testResultId) {
-      resultId = testResultId;
-    }
+        resultId = testResultId;
+      }
     if (version) {
-      testVersion = version;
-    }
+        testVersion = version;
+      }
 
     const filters: models.ITestResultFilters = {
       systemNumber: event.pathParameters.systemNumber,
@@ -79,7 +77,7 @@ export class MappingUtil {
       fromDateTime: fromDate,
       testResultId: resultId,
       testVersion,
-      testStationPNumber,
+      testStationPNumber
     };
     return filters;
   }
@@ -146,7 +144,7 @@ export class MappingUtil {
         payload.createdByName = payload.testerName;
         payload.reasonForCreation = enums.REASON_FOR_CREATION.TEST_CONDUCTED;
     }
-
+    
     payload.testTypes.forEach((testType: any) => {
       Object.assign(testType, {
         createdAt: createdAtDate,
@@ -197,30 +195,32 @@ export class MappingUtil {
     });
   }
 
-  public static addTestcodeToTestTypes =
-    (
-      service: models.TestResultsDAO,
-      params: models.TestTypeParams
-      // not sure why Ts complains as TestType has testTypeClassification key...
-    ) =>
-    async (
-      testType: any,
-      _: number,
-      testTypes: models.TestType[]
-    ): Promise<models.TestType[]> => {
-      const { testTypeId } = testType;
-      const { defaultTestCode, linkedTestCode, testTypeClassification } =
-        await service.getTestCodesAndClassificationFromTestTypes(
-          testTypeId,
-          params
-        );
-      return {
-        ...testType,
-        testTypeClassification,
-        testCode:
-          testTypes.length > 1 && linkedTestCode
-            ? linkedTestCode
-            : defaultTestCode,
-      };
+  public static addTestcodeToTestTypes = (
+    service: models.TestResultsDAO,
+    params: models.TestTypeParams
+    // not sure why Ts complains as TestType has testTypeClassification key...
+  ) => async (
+    testType: any,
+    _: number,
+    testTypes: models.TestType[]
+  ): Promise<models.TestType[]> => {
+    const { testTypeId } = testType;
+    const {
+      defaultTestCode,
+      linkedTestCode,
+      testTypeClassification,
+    } = await service.getTestCodesAndClassificationFromTestTypes(
+      testTypeId,
+      params
+    );
+    return {
+      ...testType,
+      testTypeClassification,
+      testCode:
+        testTypes.length > 1 && linkedTestCode
+          ? linkedTestCode
+          : defaultTestCode,
     };
+  };
+
 }

--- a/tests/unit/mappingUtil.unitTest.ts
+++ b/tests/unit/mappingUtil.unitTest.ts
@@ -36,7 +36,7 @@ describe("setCreatedAtAndLastUpdatedAtDates", () => {
       createdByName: "john",
       reasonForCreation: "foobar",
       createdById: "1234",
-      typeOfTest: "contingency",
+      typeOfTest: enums.TYPE_OF_TEST.CONTINGENCY,
       testTypes: [{}],
     } as models.ITestResultPayload);
     expect(payload.createdAt).toEqual(mockDate);
@@ -44,6 +44,27 @@ describe("setCreatedAtAndLastUpdatedAtDates", () => {
     expect(payload.createdById).toEqual("1234");
     expect(payload.createdByName).toEqual("john");
     expect(payload.reasonForCreation).toEqual("foobar");
+    expect(payload.testTypes[0].createdAt).toEqual(mockDate);
+    expect(payload.testTypes[0].lastUpdatedAt).toEqual(mockDate);
+  });
+
+  it("should set the audit details for contingency test", () => {
+    const payload = MappingUtil.setCreatedAtAndLastUpdatedAtDates({
+      testerStaffId: "foo",
+      testerName: "bar",
+      createdByName: "john",
+      reasonForCreation: "",
+      createdById: "1234",
+      typeOfTest: enums.TYPE_OF_TEST.DESK_BASED,
+      testTypes: [{}],
+    } as models.ITestResultPayload);
+    expect(payload.createdAt).toEqual(mockDate);
+    expect(payload.testVersion).toEqual(enums.TEST_VERSION.CURRENT);
+    expect(payload.createdById).toEqual("1234");
+    expect(payload.createdByName).toEqual("john");
+    expect(payload.reasonForCreation).toEqual(
+      enums.REASON_FOR_CREATION.TEST_CONDUCTED
+    );
     expect(payload.testTypes[0].createdAt).toEqual(mockDate);
     expect(payload.testTypes[0].lastUpdatedAt).toEqual(mockDate);
   });


### PR DESCRIPTION
## Keep user input for created by id and created by name

Allow createdById and createdByName entered by the user to persists for desk based assessments.
[CB2-6549](https://dvsa.atlassian.net/browse/CB2-6549)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
