### PR TITLE
CB2-7139 Fix expiry date calculation for leap years

### DIFF
--- a/src/handlers/expiry/providers/DateProvider.ts
+++ b/src/handlers/expiry/providers/DateProvider.ts
@@ -177,12 +177,6 @@ export class DateProvider {
     return moment(inputDate).add(1, 'years').toISOString();
   }
 
-  public static addOneYearStartOfDayISOString(
-    inputDate: Date | string,
-  ): string {
-    return moment(inputDate).add(1, 'year').startOf('day').toISOString();
-  }
-
   public static addOneYearMinusOneDayISOString(
     inputDate: Date | string,
   ): string {

--- a/src/handlers/expiry/strategies/HgvTrlFirstTestStrategy.ts
+++ b/src/handlers/expiry/strategies/HgvTrlFirstTestStrategy.ts
@@ -21,7 +21,7 @@ export class HgvTrlFirstTestStrategy implements IExpiryDateStrategy {
       isValidRegn &&
       DateProvider.isBetweenTwoMonths(regnAnniversaryEndOfMonth, testDate, '[)')
     ) {
-      return DateProvider.addOneYearStartOfDayISOString(
+      return DateProvider.getLastDayOfMonthInNextYearISOString(
         regnAnniversaryEndOfMonth,
       );
     }

--- a/tests/unit/expiry/HgvTrlFirstTestStrategy.unitTest.ts
+++ b/tests/unit/expiry/HgvTrlFirstTestStrategy.unitTest.ts
@@ -21,17 +21,26 @@ describe('HgvTrlFirstTestStrategy', () => {
 
   context('for hgv vehicle type', () => {
     describe('with valid registration date', () => {
-      describe('test hgvTrlAnnualTestStrategy with multiple scenarios', () => {
+      describe('test HgvTrlFirstTestStrategy with multiple scenarios', () => {
         test.each`
           inputRegistrationDate | inputTestDate   | ExpectedExpiryDate
           ${'2019-08-06'}       | ${'2020-06-30'} | ${'2021-06-30'}
           ${'2019-08-30'}       | ${'2020-07-01'} | ${'2021-08-31'}
+          ${'2018-12-05'}       | ${'2020-02-29'} | ${'2021-02-28'}
+          ${'2019-02-05'}       | ${'2020-02-29'} | ${'2021-02-28'}
+          ${'2019-03-05'}       | ${'2020-03-29'} | ${'2021-03-31'}
+          ${'2020-02-29'}       | ${'2021-02-15'} | ${'2022-02-28'}
+          ${'2020-02-29'}       | ${'2021-02-28'} | ${'2022-02-28'}
+          ${'2020-02-29'}       | ${'2021-03-15'} | ${'2022-03-31'}
+          ${'2022-02-05'}       | ${'2023-01-15'} | ${'2024-02-29'}
+          ${'2022-02-05'}       | ${'2023-02-28'} | ${'2024-02-29'}
+          ${'2022-02-05'}       | ${'2023-03-15'} | ${'2024-03-31'}
         `(
           'The expiry Date $ExpectedExpiryDate is calculated given a test date of $inputTestDate and a registration date of $inputRegistrationDate',
           ({ inputRegistrationDate, inputTestDate, ExpectedExpiryDate }) => {
             const hgvTestResult = cloneDeep(testResultsMockDB[4]);
             hgvTestResult.testTypes.forEach((type: TestType) => {
-              type.testTypeId = '94';
+              type.testTypeId = '64';
             });
             hgvTestResult.vehicleType = VEHICLE_TYPES.HGV;
             hgvTestResult.regnDate = inputRegistrationDate;

--- a/tests/unit/generateExpiryDate.unitTest.ts
+++ b/tests/unit/generateExpiryDate.unitTest.ts
@@ -1912,8 +1912,8 @@ describe('VehicleTestController calling generateExpiryDate', () => {
               }));
 
               const expectedExpiryDate = moment(hgvTestResult.regnDate)
-                .endOf('month')
                 .add(2, 'years')
+                .endOf('month')
                 .startOf('day');
               vehicleTestController.dataProvider.testResultsDAO =
                 new MockTestResultsDAO();
@@ -2176,8 +2176,8 @@ describe('VehicleTestController calling generateExpiryDate', () => {
               }));
 
               const expectedExpiryDate = moment(trlTestResult.firstUseDate)
-                .endOf('month')
                 .add(2, 'year')
+                .endOf('month')
                 .startOf('day');
               vehicleTestController.dataProvider.testResultsDAO =
                 new MockTestResultsDAO();


### PR DESCRIPTION
## Description
If a HGV or Trailer has a first test and its first registration anniversary is in the month of February 2022, and the test is performed before the anniversary date, the test's expiry date will be 28/02/2024 rather than 29/02/2024.
[CB2-7139](https://dvsa.atlassian.net/browse/CB2-7139)
## Evidence of Completion
Certificate created on the develop branch with the old code.
![image](https://user-images.githubusercontent.com/13391709/211205763-28b441ff-c4c0-448d-94f4-b8da7736c0da.png)
Certificate created on the vtmdev-1 branch with the new code.
![image](https://user-images.githubusercontent.com/13391709/211208357-33b5e4bf-5d92-45ca-841a-5f0d578f9160.png)
## Regression Packs
The changes were deployed to VTMDEV-1 and regression packs run.
### BE
#### Full
![image](https://user-images.githubusercontent.com/13391709/211202804-080ddde1-58b2-4b08-a354-05430e593bae.png)
Note: the two failed tests are usual for the 'full' BE regression pack.
#### Annual Cert
![image](https://user-images.githubusercontent.com/13391709/211278762-8c89f2ca-28e8-47c6-b808-739dc431dd60.png)
Note: the failed test is seen for previous runs of the 'Annual Cert' BE regression pack.
### VOTT
![image](https://user-images.githubusercontent.com/13391709/211202858-37034b74-652d-4b59-9f7e-8e24eef27c2b.png)