### PR TITLE
CB2-7277 Fix breaking integration test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,12 +190,6 @@
             "node-releases": "^1.1.71"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001230",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
-          "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.3.741",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.741.tgz",
@@ -6119,6 +6113,12 @@
           "dev": true
         }
       }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001447",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001447.tgz",
+      "integrity": "sha512-bdKU1BQDPeEXe9A39xJnGtY0uRq/z5osrnXUw0TcK+EYno45Y+U7QU9HhHEyzvMDffpYadFXi3idnSNkcwLkTw==",
+      "dev": true
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -13934,7 +13934,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json5": {
@@ -18359,7 +18359,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "throat": {

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -27,10 +27,9 @@ const setupServer = (process: any) =>
       if (code !== 137) {
         console.info(
           `process terminated with code: ${code} and signal: ${signal}`,
-        )
+        );
       }
-    }
-    );
+    });
   });
 
 const server = spawn('npm', ['run', 'start'], {});

--- a/tests/integration/getTestResultsBySystemNumber.intTest.ts
+++ b/tests/integration/getTestResultsBySystemNumber.intTest.ts
@@ -34,9 +34,9 @@ describe('getTestResultsBySystemNumber', () => {
         context(
           'and there are test results in the db that satisfy both conditions',
           () => {
-            it("should return the test results for that systemNumber with status 'submitted' and that have createdAt value between 2017-01-01 and 2021-02-23", async () => {
+            it("should return the test results for that systemNumber with status 'submitted' and that have createdAt value between 2021-01-01 and 2023-02-23", async () => {
               const res = await request.get(
-                'test-results/11000002?status=submitted&fromDateTime=2021-01-01&toDateTime=2021-02-23',
+                'test-results/11000002?status=submitted&fromDateTime=2021-01-01&toDateTime=2023-02-23',
               );
               expect(res.status).toBe(200);
               expect(res.header['access-control-allow-origin']).toBe('*');

--- a/tests/resources/test-results.json
+++ b/tests/resources/test-results.json
@@ -211,9 +211,9 @@
     "testResultId": "2",
     "systemNumber": "11000002",
     "testerStaffId": "15",
-    "testStartTimestamp": "2021-01-14T10:36:33.987Z",
+    "testStartTimestamp": "2023-01-14T10:36:33.987Z",
     "odometerReadingUnits": "kilometres",
-    "testEndTimestamp": "2021-01-14T10:36:33.987Z",
+    "testEndTimestamp": "2023-01-14T10:36:33.987Z",
     "testStatus": "submitted",
     "numberOfWheelsDriven": 3,
     "testTypes": [

--- a/tests/unit/getTestResultsByTesterStaffId.unitTest.ts
+++ b/tests/unit/getTestResultsByTesterStaffId.unitTest.ts
@@ -121,7 +121,7 @@ describe('getTestResultsByTesterStaffId path of TestResultsService', () => {
         testerStaffId: '15',
         testStationPNumber: '84-926821',
         fromDateTime: '2015-02-22',
-        toDateTime: '2021-02-22',
+        toDateTime: '2023-02-22',
         testStatus: 'submitted',
       };
       const filteredTestResults = cloneDeep(testResultsMockDB).filter(


### PR DESCRIPTION
## Description

There was a test failing when running the integration tests for test-results. It was caused by the test data falling outside of the two year window for a search by system number with no search parameters.
[CB2-7277](https://dvsa.atlassian.net/browse/CB2-7277)

## Evidence of Completion
### Integration Tests
![image](https://user-images.githubusercontent.com/13391709/214302126-fec170b1-5802-4090-ae9e-16a354cbb142.png)

### Unit Tests
![image](https://user-images.githubusercontent.com/13391709/214301766-e79efe0a-f2c7-4c3f-bfc6-33813701b94a.png)
