### PR TITLE
fix(cb2-7726): light vehicles should have optional defects

### DIFF
--- a/src/models/validators/TestResultsSchemaCarSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaCarSubmitted.ts
@@ -1,7 +1,20 @@
-import * as Joi from 'joi';
-import { testResultsCommonSchemaSpecialistTestsSubmitted } from './SpecialistTestsCommonSchemaSubmitted';
+import { array, string } from 'joi';
+import {
+  defectsCommonSchemaSpecialistTestsSubmitted,
+  testResultsCommonSchemaSpecialistTestsSubmitted,
+  testTypesCommonSchemaSpecialistTestsSubmitted,
+} from './SpecialistTestsCommonSchemaSubmitted';
 
 export const carSubmitted =
   testResultsCommonSchemaSpecialistTestsSubmitted.keys({
-    vehicleSubclass: Joi.array().items(Joi.string()).required().allow(null),
+    vehicleSubclass: array().items(string()).required().allow(null),
+    testTypes: array()
+      .items(
+        testTypesCommonSchemaSpecialistTestsSubmitted.keys({
+          defects: array()
+            .items(defectsCommonSchemaSpecialistTestsSubmitted)
+            .optional(),
+        }),
+      )
+      .required(),
   });

--- a/src/models/validators/TestResultsSchemaLGVSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaLGVSubmitted.ts
@@ -1,7 +1,20 @@
-import * as Joi from 'joi';
-import { testResultsCommonSchemaSpecialistTestsSubmitted } from './SpecialistTestsCommonSchemaSubmitted';
+import { string, array } from 'joi';
+import {
+  defectsCommonSchemaSpecialistTestsSubmitted,
+  testResultsCommonSchemaSpecialistTestsSubmitted,
+  testTypesCommonSchemaSpecialistTestsSubmitted,
+} from './SpecialistTestsCommonSchemaSubmitted';
 
 export const lgvSubmitted =
   testResultsCommonSchemaSpecialistTestsSubmitted.keys({
-    vehicleSubclass: Joi.array().items(Joi.string()).required().allow(null),
+    vehicleSubclass: array().items(string()).required().allow(null),
+    testTypes: array()
+      .items(
+        testTypesCommonSchemaSpecialistTestsSubmitted.keys({
+          defects: array()
+            .items(defectsCommonSchemaSpecialistTestsSubmitted)
+            .optional(),
+        }),
+      )
+      .required(),
   });

--- a/src/models/validators/TestResultsSchemaMotorcycleSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaMotorcycleSubmitted.ts
@@ -1,11 +1,16 @@
-import * as Joi from 'joi';
-import { testResultsCommonSchemaSpecialistTestsSubmitted } from './SpecialistTestsCommonSchemaSubmitted';
+// import * as Joi from 'joi';
+import { any, array, object } from 'joi';
+import {
+  defectsCommonSchemaSpecialistTestsSubmitted,
+  testResultsCommonSchemaSpecialistTestsSubmitted,
+  testTypesCommonSchemaSpecialistTestsSubmitted,
+} from './SpecialistTestsCommonSchemaSubmitted';
 
 export const motorcycleSubmitted =
   testResultsCommonSchemaSpecialistTestsSubmitted.keys({
-    vehicleClass: Joi.object()
+    vehicleClass: object()
       .keys({
-        code: Joi.any()
+        code: any()
           .only([
             '1',
             '2',
@@ -22,7 +27,7 @@ export const motorcycleSubmitted =
             'u',
           ])
           .required(),
-        description: Joi.any().only([
+        description: any().only([
           'motorbikes up to 200cc',
           'motorbikes over 200cc or with a sidecar',
           '3 wheelers',
@@ -38,5 +43,14 @@ export const motorcycleSubmitted =
           'Not Known',
         ]),
       })
+      .required(),
+    testTypes: array()
+      .items(
+        testTypesCommonSchemaSpecialistTestsSubmitted.keys({
+          defects: array()
+            .items(defectsCommonSchemaSpecialistTestsSubmitted)
+            .optional(),
+        }),
+      )
       .required(),
   });


### PR DESCRIPTION
## Make defects optional for light vehicles

Light vehicles don't need defects. Forcing defects to be there in VTM causes problems.
[CB2-7726](https://dvsa.atlassian.net/browse/CB2-7726)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
