### PR TITLE
fix(7844): makes vehicle class optional in update

### DIFF
--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -347,7 +347,7 @@ export class VehicleTestController implements IVehicleTestController {
       vehicleConfiguration,
       vehicleAxles: newTestResult.noOfAxles,
       euVehicleCategory,
-      vehicleClass: newTestResult.vehicleClass.code,
+      vehicleClass: newTestResult.vehicleClass?.code,
       vehicleSubclass,
       vehicleWheels: newTestResult.numberOfWheelsDriven,
     });


### PR DESCRIPTION
## Error 502 when amending DBA tests for car and LGV

Vehicle class is not present for LGV and cars
[CB2-7844](https://dvsa.atlassian.net/browse/CB2-7844)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
