### PR TITLE
fix(cb2-7844): makes vehicle class optional in test-result update

### DIFF
--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -347,7 +347,7 @@ export class VehicleTestController implements IVehicleTestController {
       vehicleConfiguration,
       vehicleAxles: newTestResult.noOfAxles,
       euVehicleCategory,
-      vehicleClass: newTestResult.vehicleClass.code,
+      vehicleClass: newTestResult.vehicleClass?.code,
       vehicleSubclass,
       vehicleWheels: newTestResult.numberOfWheelsDriven,
     });


### PR DESCRIPTION
## Error 502 when amending DBA tests for car and LGV

Vehicle class is not present for LGV and cars, hence adding an optional check to avoid error.

[CB2-7844](https://dvsa.atlassian.net/browse/CB2-7844)

## Checklist

- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number
