### PR TITLE
fix(CB2-7942): CommonSchema Joi Update

### DIFF
--- a/src/models/validators/CommonSchema.ts
+++ b/src/models/validators/CommonSchema.ts
@@ -139,7 +139,7 @@ export const testResultsCommonSchema = Joi.object().keys({
   noOfAxles: Joi.number().max(99).required(),
   preparerId: Joi.string().required().allow('', null),
   preparerName: Joi.string().required().allow('', null),
-  numberOfWheelsDriven: Joi.number().required().allow(null),
+  numberOfWheelsDriven: Joi.number().required().allow('', null),
   regnDate: Joi.string().allow('', null),
   firstUseDate: Joi.string().allow('', null),
   euVehicleCategory: Joi.any()


### PR DESCRIPTION
Updated the CommonSchema Joi schema so that the testResultsCommonSchema now allows empty strings in the numberOfWheelsDriven field.

[[link to ticket number](https://dvsa.atlassian.net/browse/CB2-7942)]

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
