### PR TITLE
fix(cb2 8250) vrm maximum field length for psv

### DIFF
--- a/src/models/validators/TestResultsSchemaPSVCancelled.ts
+++ b/src/models/validators/TestResultsSchemaPSVCancelled.ts
@@ -51,7 +51,7 @@ const testTypesSchema = testTypesCommonSchema.keys({
 });
 
 export const psvCancelled = testResultsCommonSchema.keys({
-  vrm: Joi.string().alphanum().min(1).max(9).required(),
+  vrm: Joi.string().alphanum().min(1).max(8).required(),
   reasonForCancellation: Joi.string().max(500).required().allow('', null),
   numberOfSeats: Joi.number().required(),
   odometerReading: Joi.number().required().allow(null),

--- a/src/models/validators/TestResultsSchemaPSVCancelled.ts
+++ b/src/models/validators/TestResultsSchemaPSVCancelled.ts
@@ -51,7 +51,7 @@ const testTypesSchema = testTypesCommonSchema.keys({
 });
 
 export const psvCancelled = testResultsCommonSchema.keys({
-  vrm: Joi.string().alphanum().min(1).max(8).required(),
+  vrm: Joi.string().alphanum().min(1).max(9).required(),
   reasonForCancellation: Joi.string().max(500).required().allow('', null),
   numberOfSeats: Joi.number().required(),
   odometerReading: Joi.number().required().allow(null),

--- a/src/models/validators/TestResultsSchemaPSVSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaPSVSubmitted.ts
@@ -54,7 +54,7 @@ const testTypesSchema = testTypesCommonSchema.keys({
 });
 
 export const psvSubmitted = testResultsCommonSchema.keys({
-  vrm: Joi.string().alphanum().min(1).max(8).required(),
+  vrm: Joi.string().alphanum().min(1).max(9).required(),
   numberOfSeats: Joi.number().required(),
   odometerReading: Joi.number().required().allow(null),
   odometerReadingUnits: Joi.any()

--- a/src/models/validators/TestResultsSchemaPSVSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaPSVSubmitted.ts
@@ -54,7 +54,7 @@ const testTypesSchema = testTypesCommonSchema.keys({
 });
 
 export const psvSubmitted = testResultsCommonSchema.keys({
-  vrm: Joi.string().alphanum().min(1).max(9).required(),
+  vrm: Joi.string().alphanum().min(1).max(8).required(),
   numberOfSeats: Joi.number().required(),
   odometerReading: Joi.number().required().allow(null),
   odometerReadingUnits: Joi.any()


### PR DESCRIPTION
## VRM field maximum length for PSV

Changed the maximum length of the VRM field to 9 for PSV as per original requirements instead of the previous maximum length of 8 characters long.
[CB2-8250](https://dvsa.atlassian.net/browse/CB2-8250)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
