### PR TITLE
fix(cb2-9796): remove validation for hidden field

### DIFF
--- a/src/models/validators/test-types/testTypesSchemaDeskBasedTestsPut.ts
+++ b/src/models/validators/test-types/testTypesSchemaDeskBasedTestsPut.ts
@@ -110,11 +110,7 @@ export const testTypesDeskBasedGroup5 =
       then: Joi.string().required(),
       otherwise: Joi.string().allow('', null),
     }),
-    secondaryCertificateNumber: Joi.any().when('vehicleType', {
-      is: 'hgv',
-      then: Joi.string().required(),
-      otherwise: Joi.string().allow('', null),
-    }),
+    secondaryCertificateNumber: Joi.string().allow('', null),
     testExpiryDate: Joi.date().allow('', null),
   });
 

--- a/tests/unit/validationUtil.unitTest.ts
+++ b/tests/unit/validationUtil.unitTest.ts
@@ -1,6 +1,67 @@
 import { ITestResult } from '../../src/models';
 import { ValidationUtil } from '../../src/utils/validationUtil';
 
+describe('validateTestTypes with desk based group 5', () => {
+  it('fails validation with hgv and null certificateNumber', () => {
+    const testResult = {
+      testResultId: '32e9aa52-f10b-4619-bad1-044c5227f93c',
+      vehicleType: 'hgv',
+      typeOfTest: 'desk-based',
+      source: 'vtm',
+      testStatus: 'submitted',
+      systemNumber: '10000001',
+      testerStaffId: 'e12345650954260',
+      testEndTimestamp: '2023-10-20T10:06:13.242Z',
+      vehicleClass: {
+        code: 'v',
+        description: 'heavy goods vehicle',
+      },
+      noOfAxles: 1,
+      numberOfWheelsDriven: null,
+      regnDate: null,
+      firstUseDate: null,
+      createdByName: 'tester',
+      createdById: 'e12345650954260',
+      vehicleConfiguration: 'rigid',
+      reasonForCancellation: null,
+      testTypes: [
+        {
+          testTypeId: '441',
+          name: 'Type approved tractor unit - Great Britain',
+          secondaryCertificateNumber: null,
+          createdAt: '2023-10-20T10:06:35.901Z',
+          lastUpdatedAt: '2023-10-20T10:06:35.901Z',
+          testTypeClassification: 'NON ANNUAL',
+          testNumber: 'W01A00128',
+          testCode: 'nft',
+          testResult: 'pass',
+          certificateNumber: null,
+          testTypeStartTimestamp: '2023-10-20T10:06:13.242Z',
+          testTypeEndTimestamp: '2023-10-20T10:06:13.242Z',
+          additionalNotesRecorded: 'sdfgsdfg',
+          defects: [],
+          customDefects: [],
+        },
+      ],
+      vin: 'ASDFGHJKL',
+      countryOfRegistration: 'a',
+      euVehicleCategory: 'm2',
+      preparerName: 'asdfu',
+      preparerId: 'gfdsf',
+      testStartTimestamp: '2023-10-20T10:06:13.242Z',
+      createdAt: '2023-10-20T10:29:29.343Z',
+      testStationName: 'place',
+      testStationPNumber: '14-7160003',
+      testStationType: 'hq',
+      testerName: 'tester',
+      testerEmailAddress: 'user@test.com',
+      reasonForCreation: 'sdfgh',
+    } as unknown as ITestResult;
+    const expected = ValidationUtil.validateTestTypes(testResult);
+
+    expect(expected).toEqual(['"certificateNumber" must be a string']);
+  });
+});
 describe('validateTestTypes with desk based group 4', () => {
   it('passes validation with a trl and null certificateNumber', () => {
     const testResult = {


### PR DESCRIPTION
## Cannot amend a CDV test for an HGV

secondaryCertificateNumber is not a required field for group 5 tests for HGV, hence removing the validation

[CB2-9796](https://dvsa.atlassian.net/browse/CB2-9796)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
