### PR TITLE
feat(cb2-9716): Make odometer readings optional for IVA tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "ISC",
       "dependencies": {
         "@dvsa/cvs-type-definitions": "4.0.0",
-        "@types/express-serve-static-core": "4.17.20",
         "aws-lambda": "^1.0.7",
         "aws-sdk": "^2.1354.0",
         "aws-xray-sdk": "^3.3.4",
@@ -30,6 +29,7 @@
         "@commitlint/config-conventional": "^12.1.4",
         "@dvsa/eslint-config-ts": "^3.0.0",
         "@types/aws-lambda": "^8.10.109",
+        "@types/express-serve-static-core": "4.17.20",
         "@types/jest": "^24.0.21",
         "@types/jest-plugin-context": "^2.9.2",
         "@types/joi": "^14.3.3",

--- a/src/models/validators/TestResultsSchemaCarSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaCarSubmitted.ts
@@ -12,10 +12,10 @@ export const carSubmitted =
     testTypes: array()
       .items(
         testTypesCommonSchemaSpecialistTestsSubmitted.keys({
-            defects: array()
-                .items(defectsCommonSchemaSpecialistTestsSubmitted)
-                .optional(),
-            ivaDefects: array().items(ivaDefectSchema).required(),
+          defects: array()
+            .items(defectsCommonSchemaSpecialistTestsSubmitted)
+            .optional(),
+          ivaDefects: array().items(ivaDefectSchema).required(),
         }),
       )
       .required(),

--- a/src/utils/validationUtil.ts
+++ b/src/utils/validationUtil.ts
@@ -346,7 +346,7 @@ export class ValidationUtil {
     ) {
       missingMandatoryFields.push(enums.ERRORS.OdometerReadingMandatory);
     }
-    if (!odometerReadingUnits) {
+    if (!ValidationUtil.isIvaTest(testTypes) && !odometerReadingUnits) {
       missingMandatoryFields.push(enums.ERRORS.OdometerReadingUnitsMandatory);
     }
     return missingMandatoryFields;

--- a/src/utils/validationUtil.ts
+++ b/src/utils/validationUtil.ts
@@ -299,7 +299,7 @@ export class ValidationUtil {
       '196',
       '197',
     ];
-    return tests.some((test: models.TestType) =>
+    return tests.every((test: models.TestType) =>
       ivaTests.includes(test.testTypeId),
     );
   }

--- a/src/utils/validationUtil.ts
+++ b/src/utils/validationUtil.ts
@@ -258,6 +258,52 @@ export class ValidationUtil {
     return missingFields;
   }
 
+  private static isIvaTest(tests: models.TestType[]): boolean {
+    const ivaTests = [
+      '125',
+      '126',
+      '128',
+      '129',
+      '130',
+      '133',
+      '134',
+      '135',
+      '136',
+      '138',
+      '139',
+      '140',
+      '153',
+      '154',
+      '158',
+      '159',
+      '162',
+      '163',
+      '166',
+      '167',
+      '169',
+      '170',
+      '172',
+      '173',
+      '184',
+      '185',
+      '186',
+      '187',
+      '188',
+      '189',
+      '190',
+      '191',
+      '192',
+      '193',
+      '194',
+      '195',
+      '196',
+      '197',
+    ];
+    return tests.some((test: models.TestType) =>
+      ivaTests.includes(test.testTypeId),
+    );
+  }
+
   private static validateMandatoryTestResultFields(
     payload: models.ITestResultPayload,
   ): string[] {
@@ -290,13 +336,14 @@ export class ValidationUtil {
       missingMandatoryFields.push(enums.ERRORS.EuVehicleCategoryMandatory);
     }
 
-    if (
-      ![enums.VEHICLE_TYPES.HGV, enums.VEHICLE_TYPES.PSV].includes(vehicleType)
-    ) {
+    if (vehicleType === enums.VEHICLE_TYPES.TRL) {
       return missingMandatoryFields;
     }
-    // odometerReading and odoMeterReadingUnits are required only for HGV and PSV
-    if (odometerReading === undefined || odometerReading === null) {
+    // odometerReading and odoMeterReadingUnits are not required for TRL
+    if (
+      !ValidationUtil.isIvaTest(testTypes) &&
+      (odometerReading === undefined || odometerReading === null)
+    ) {
       missingMandatoryFields.push(enums.ERRORS.OdometerReadingMandatory);
     }
     if (!odometerReadingUnits) {

--- a/tests/unit/validationUtil.unitTest.ts
+++ b/tests/unit/validationUtil.unitTest.ts
@@ -1,4 +1,4 @@
-import { ITestResult } from '../../src/models';
+import { ITestResult, TestType } from '../../src/models';
 import { ValidationUtil } from '../../src/utils/validationUtil';
 
 describe('validateTestTypes with desk based group 5', () => {
@@ -305,4 +305,42 @@ describe('validateTestTypes with desk based group 3', () => {
     const result = ValidationUtil.validateTestTypes(testResult);
     expect(result).toEqual(['"certificateNumber" is required']);
   });
+
+  describe('Is IVA test', () => {
+    it('Should return true if given 1 IVA test', () => {
+      const tests = [{testTypeId: '125'}] as unknown as TestType[];
+
+      const result = (ValidationUtil as any).isIvaTest(tests);
+
+      expect(result).toBeTruthy();
+    });
+    it('Should return true if given 2 IVA tests', () => {
+      const tests = [{testTypeId: '125'}, {testTypeId: '126'}] as unknown as TestType[];
+
+      const result = (ValidationUtil as any).isIvaTest(tests);
+
+      expect(result).toBeTruthy();
+    });
+    it('Should return false if given 1 non-IVA test', () => {
+      const tests = [{testTypeId: '94'}] as unknown as TestType[];
+
+      const result = (ValidationUtil as any).isIvaTest(tests);
+
+      expect(result).toBeFalsy();
+    });
+    it('Should return false if given 2 non-IVA tests', () => {
+      const tests = [{testTypeId: '94'}, {testTypeId: '95'}] as unknown as TestType[];
+
+      const result = (ValidationUtil as any).isIvaTest(tests);
+
+      expect(result).toBeFalsy();
+    });
+    it('Should return false if given 1 IVA and 1 non-IVA test', () => {
+      const tests = [{testTypeId: '94'}, {testTypeId: '126'}] as unknown as TestType[];
+
+      const result = (ValidationUtil as any).isIvaTest(tests);
+
+      expect(result).toBeFalsy();
+    });
+  })
 });

--- a/tests/unit/validationUtil.unitTest.ts
+++ b/tests/unit/validationUtil.unitTest.ts
@@ -308,39 +308,48 @@ describe('validateTestTypes with desk based group 3', () => {
 
   describe('Is IVA test', () => {
     it('Should return true if given 1 IVA test', () => {
-      const tests = [{testTypeId: '125'}] as unknown as TestType[];
+      const tests = [{ testTypeId: '125' }] as unknown as TestType[];
 
       const result = (ValidationUtil as any).isIvaTest(tests);
 
       expect(result).toBeTruthy();
     });
     it('Should return true if given 2 IVA tests', () => {
-      const tests = [{testTypeId: '125'}, {testTypeId: '126'}] as unknown as TestType[];
+      const tests = [
+        { testTypeId: '125' },
+        { testTypeId: '126' },
+      ] as unknown as TestType[];
 
       const result = (ValidationUtil as any).isIvaTest(tests);
 
       expect(result).toBeTruthy();
     });
     it('Should return false if given 1 non-IVA test', () => {
-      const tests = [{testTypeId: '94'}] as unknown as TestType[];
+      const tests = [{ testTypeId: '94' }] as unknown as TestType[];
 
       const result = (ValidationUtil as any).isIvaTest(tests);
 
       expect(result).toBeFalsy();
     });
     it('Should return false if given 2 non-IVA tests', () => {
-      const tests = [{testTypeId: '94'}, {testTypeId: '95'}] as unknown as TestType[];
+      const tests = [
+        { testTypeId: '94' },
+        { testTypeId: '95' },
+      ] as unknown as TestType[];
 
       const result = (ValidationUtil as any).isIvaTest(tests);
 
       expect(result).toBeFalsy();
     });
     it('Should return false if given 1 IVA and 1 non-IVA test', () => {
-      const tests = [{testTypeId: '94'}, {testTypeId: '126'}] as unknown as TestType[];
+      const tests = [
+        { testTypeId: '94' },
+        { testTypeId: '126' },
+      ] as unknown as TestType[];
 
       const result = (ValidationUtil as any).isIvaTest(tests);
 
       expect(result).toBeFalsy();
     });
-  })
+  });
 });


### PR DESCRIPTION
## Ticket title

Update tests to allow no odometer reading on IVA & add unit tests.

[CB2-9716](https://dvsa.atlassian.net/browse/CB2-9716?atlOrigin=eyJpIjoiZWFiMjgwY2M3YzJiNGI0YTllMmI5MzAzZTQ2NDQ4YTAiLCJwIjoiaiJ9)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
