### PR TITLE
feat(cb2 10477): making specialist test type referenceNumber optional

### DIFF
--- a/docs/test-results-api.yml
+++ b/docs/test-results-api.yml
@@ -736,7 +736,10 @@ components:
       type: array
       nullable: true
       items:
-        $ref: '#/components/schemas/customDefect'
+        type: object
+        oneOf:
+          - $ref: '#/components/schemas/customDefect'
+          - $ref: '#/components/schemas/specialistCustomDefect'
     customDefect:
       type: object
       properties:
@@ -750,6 +753,20 @@ components:
           type: string
           maxLength: 200
           nullable: true
+    specialistCustomDefect:
+      type: object
+      properties:
+        referenceNumber:
+          type: string
+          maxLength: 10
+          nullable: false
+        defectName:
+          type: string
+          maxLength: 200
+        defectNotes:
+          type: string
+          maxLength: 200
+          nullable: true    
     putBadRequest:
       type: object
       properties:

--- a/docs/test-results-api.yml
+++ b/docs/test-results-api.yml
@@ -766,7 +766,7 @@ components:
         defectNotes:
           type: string
           maxLength: 200
-          nullable: true    
+          nullable: true
     putBadRequest:
       type: object
       properties:

--- a/docs/test-results-api.yml
+++ b/docs/test-results-api.yml
@@ -759,7 +759,7 @@ components:
         referenceNumber:
           type: string
           maxLength: 10
-          nullable: false
+          nullable: true
         defectName:
           type: string
           maxLength: 200

--- a/src/models/validators/CommonSchema.ts
+++ b/src/models/validators/CommonSchema.ts
@@ -11,6 +11,71 @@ const customInspectionTypesErrorMessage = (
       : e,
   );
 
+const baseTestTypesCommonSchema = Joi.object().keys({
+  name: Joi.string().required(),
+  testTypeName: Joi.string().required().allow('', null),
+  testTypeId: Joi.string().required().allow(''),
+  testTypeStartTimestamp: Joi.date().iso().required(),
+  certificateNumber: Joi.string().required().allow('', null),
+  prohibitionIssued: Joi.boolean().required().allow(null),
+  reasonForAbandoning: Joi.string().required().allow('', null),
+  additionalNotesRecorded: Joi.string().max(500).required().allow('', null),
+  additionalCommentsForAbandon: Joi.string()
+    .max(500)
+    .required()
+    .allow('', null),
+  testExpiryDate: Joi.date()
+    .when('testResult', {
+      is: 'pass',
+      then: Joi.date().iso().allow(null),
+      otherwise: Joi.date().allow(null, ''),
+    })
+    .allow(null),
+  modType: Joi.object()
+    .keys({
+      code: Joi.any().only(['p', 'm', 'g']),
+      description: Joi.any().only([
+        'particulate trap',
+        'modification or change of engine',
+        'gas engine',
+      ]),
+    })
+    .allow(null),
+  secondaryCertificateNumber: Joi.string()
+    .alphanum()
+    .max(20)
+    .required()
+    .allow(null),
+  emissionStandard: Joi.any()
+    .only([
+      '0.10 g/kWh Euro 3 PM',
+      '0.03 g/kWh Euro IV PM',
+      'Euro 3',
+      'Euro 4',
+      'Euro 5',
+      'Euro 6',
+      'Euro V',
+      'Euro VI',
+      'Full Electric',
+    ])
+    .allow(null),
+  fuelType: Joi.any()
+    .only([
+      'diesel',
+      'gas-cng',
+      'gas-lng',
+      'gas-lpg',
+      'petrol',
+      'fuel cell',
+      'full electric',
+    ])
+    .allow(null),
+  particulateTrapSerialNumber: Joi.string().max(100).allow(null),
+  smokeTestKLimitApplied: Joi.string().max(100).allow(null),
+  modificationTypeUsed: Joi.string().max(100).allow(null),
+  particulateTrapFitted: Joi.string().max(100).allow(null),
+});
+
 export const ivaDefectSchema = Joi.object({
   sectionNumber: Joi.string().required(),
   sectionDescription: Joi.string().required(),
@@ -62,36 +127,7 @@ export const defectsCommonSchema = Joi.object().keys({
   prs: Joi.boolean().required().allow(null),
 });
 
-export const testTypesCommonSchema = Joi.object().keys({
-  name: Joi.string().required(),
-  testTypeName: Joi.string().required().allow('', null),
-  testTypeId: Joi.string().required().allow(''),
-  testTypeStartTimestamp: Joi.date().iso().required(),
-  certificateNumber: Joi.string().required().allow('', null),
-  prohibitionIssued: Joi.boolean().required().allow(null),
-  reasonForAbandoning: Joi.string().required().allow('', null),
-  additionalNotesRecorded: Joi.string().max(500).required().allow('', null),
-  additionalCommentsForAbandon: Joi.string()
-    .max(500)
-    .required()
-    .allow('', null),
-  testExpiryDate: Joi.date()
-    .when('testResult', {
-      is: 'pass',
-      then: Joi.date().iso().allow(null),
-      otherwise: Joi.date().allow(null, ''),
-    })
-    .allow(null),
-  modType: Joi.object()
-    .keys({
-      code: Joi.any().only(['p', 'm', 'g']),
-      description: Joi.any().only([
-        'particulate trap',
-        'modification or change of engine',
-        'gas engine',
-      ]),
-    })
-    .allow(null),
+export const testTypesCommonSchema = baseTestTypesCommonSchema.keys({
   customDefects: Joi.array()
     .items(
       Joi.object().keys({
@@ -102,39 +138,19 @@ export const testTypesCommonSchema = Joi.object().keys({
     )
     .required()
     .allow(null),
-  secondaryCertificateNumber: Joi.string()
-    .alphanum()
-    .max(20)
+});
+
+export const testTypesSpecialistSchema = baseTestTypesCommonSchema.keys({
+  customDefects: Joi.array()
+    .items(
+      Joi.object().keys({
+        referenceNumber: Joi.string().max(10).optional(),
+        defectName: Joi.string().max(200).required(),
+        defectNotes: Joi.string().max(200).required().allow(null),
+      }),
+    )
     .required()
     .allow(null),
-  emissionStandard: Joi.any()
-    .only([
-      '0.10 g/kWh Euro 3 PM',
-      '0.03 g/kWh Euro IV PM',
-      'Euro 3',
-      'Euro 4',
-      'Euro 5',
-      'Euro 6',
-      'Euro V',
-      'Euro VI',
-      'Full Electric',
-    ])
-    .allow(null),
-  fuelType: Joi.any()
-    .only([
-      'diesel',
-      'gas-cng',
-      'gas-lng',
-      'gas-lpg',
-      'petrol',
-      'fuel cell',
-      'full electric',
-    ])
-    .allow(null),
-  particulateTrapSerialNumber: Joi.string().max(100).allow(null),
-  smokeTestKLimitApplied: Joi.string().max(100).allow(null),
-  modificationTypeUsed: Joi.string().max(100).allow(null),
-  particulateTrapFitted: Joi.string().max(100).allow(null),
 });
 
 export const testResultsCommonSchema = Joi.object().keys({

--- a/src/models/validators/SpecialistTestsCommonSchemaCancelled.ts
+++ b/src/models/validators/SpecialistTestsCommonSchemaCancelled.ts
@@ -2,7 +2,7 @@ import * as Joi from 'joi';
 import {
   defectsCommonSchema,
   testResultsCommonSchema,
-  testTypesCommonSchema,
+  testTypesSpecialistSchema,
   ivaDefectSchema,
 } from './CommonSchema';
 
@@ -32,7 +32,7 @@ export const defectsCommonSchemaSpecialistTestsCancelled =
   });
 
 export const testTypesCommonSchemaSpecialistTestsCancelled =
-  testTypesCommonSchema.keys({
+  testTypesSpecialistSchema.keys({
     testResult: Joi.any()
       .only(['fail', 'pass', 'prs', 'abandoned'])
       .required()

--- a/src/models/validators/SpecialistTestsCommonSchemaSubmitted.ts
+++ b/src/models/validators/SpecialistTestsCommonSchemaSubmitted.ts
@@ -3,11 +3,11 @@ import {
   defectsCommonSchema,
   ivaDefectSchema,
   testResultsCommonSchema,
-  testTypesCommonSchema,
+  testTypesSpecialistSchema,
 } from './CommonSchema';
 
 export const testTypesIVADefectCommonSchemaSpecialistTestsSubmitted =
-  testTypesCommonSchema.keys({
+  testTypesSpecialistSchema.keys({
     testTypeEndTimestamp: Joi.date().iso().required(),
     testResult: Joi.any().only(['fail', 'pass', 'prs', 'abandoned']).required(),
     ivaDefects: Joi.array().items(ivaDefectSchema.required()).optional(),
@@ -45,7 +45,7 @@ export const defectsCommonSchemaSpecialistTestsSubmitted =
   });
 
 export const testTypesCommonSchemaSpecialistTestsSubmitted =
-  testTypesCommonSchema.keys({
+  testTypesSpecialistSchema.keys({
     testTypeEndTimestamp: Joi.date().iso().required(),
     testResult: Joi.any().only(['fail', 'pass', 'prs', 'abandoned']).required(),
     defects: Joi.array()

--- a/src/models/validators/test-types/testTypesSchemaSpecialistTestsPut.ts
+++ b/src/models/validators/test-types/testTypesSchemaSpecialistTestsPut.ts
@@ -21,7 +21,7 @@ export const testTypesCommonSchemaSpecialistTests = Joi.object()
     customDefects: Joi.array()
       .items(
         Joi.object().keys({
-          referenceNumber: Joi.string().max(10).required(),
+          referenceNumber: Joi.string().max(10).optional(),
           defectName: Joi.string().max(200).required(),
           defectNotes: Joi.string().max(200).required(),
         }),


### PR DESCRIPTION
## Updating referenceNumber for Specialist test types

The referenceNumber property of custom defects has been made optional for specialist test types only, non specialist test types remain mandatory.
[https://dvsa.atlassian.net/browse/CB2-10477](CB2-10477)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
