### PR TITLE
cb2-10476: Allow Additional Information and PRS to be set per Required Standards

### DIFF
--- a/docs/test-results-api.yml
+++ b/docs/test-results-api.yml
@@ -792,7 +792,7 @@ components:
         inspectionTypes:
           type: array
           items:
-            $ref: '#/components/schemas/inspectionType' 
+            $ref: '#/components/schemas/inspectionType'
         prs:
           type: boolean
         additionalNotes:

--- a/docs/test-results-api.yml
+++ b/docs/test-results-api.yml
@@ -631,6 +631,8 @@ components:
 
         defects:
           $ref: '#/components/schemas/defects'
+        ivaDefects:
+          $ref: '#/components/schemas/ivaDefects'
         customDefects:
           $ref: '#/components/schemas/customDefects'
     defects:
@@ -767,6 +769,39 @@ components:
           type: string
           maxLength: 200
           nullable: true
+    ivaDefects:
+      type: array
+      nullable: true
+      items:
+        $ref: '#/components/schemas/ivaDefect'
+    ivaDefect:
+      type: object
+      properties:
+        sectionNumber:
+          type: string
+        sectionDescription:
+          type: string
+        rsNumber:
+          type: number
+        requiredStandard:
+          type: string
+        refCalculation:
+          type: string
+        additionalInfo:
+          type: boolean
+        inspectionTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/inspectionType' 
+        prs:
+          type: boolean
+        additionalNotes:
+          type: string
+    inspectionType:
+      type: string
+      enum:
+        - basic
+        - normal
     putBadRequest:
       type: object
       properties:

--- a/src/models/ITestResult.ts
+++ b/src/models/ITestResult.ts
@@ -1,4 +1,4 @@
-import {InspectionType} from '@dvsa/cvs-type-definitions/types/iva/defects/get';
+import { InspectionType } from '@dvsa/cvs-type-definitions/types/iva/defects/get';
 
 export interface ITestResult {
   testResultId: string;

--- a/src/models/ITestResult.ts
+++ b/src/models/ITestResult.ts
@@ -1,4 +1,4 @@
-import { SectionIVA } from '@dvsa/cvs-type-definitions/types/iva/defects/get';
+import { InspectionType, SectionIVA } from '@dvsa/cvs-type-definitions/types/iva/defects/get';
 
 export interface ITestResult {
   testResultId: string;
@@ -67,7 +67,7 @@ export interface TestType {
   seatbeltInstallationCheckDate?: boolean | null; // mandatory for PSV only, not applicable for HGV and TRL
   additionalNotesRecorded: string;
   defects: Defect[];
-  ivaDefects?: SectionIVA[];
+  ivaDefects?: DefectIVA[];
   name: string;
   certificateLink?: string | null; // Not sent from FE, calculated in the BE.
   testTypeClassification?: string; // field not present in API specs and is removed during POST but present in all json objects
@@ -100,6 +100,18 @@ export interface Defect {
   itemDescription: string;
   imNumber: number;
   prohibitionIssued?: boolean;
+}
+
+export interface DefectIVA{
+  sectionNumber: string;
+  sectionDescription: string;  
+  rsNumber: number;
+  requiredStandard: string;
+  refCalculation: string;
+  additionalInfo: boolean;
+  inspectionTypes: InspectionType[];
+  prs: boolean;
+  additionalNotes?: string;
 }
 
 export interface AdditionalInformation {

--- a/src/models/ITestResult.ts
+++ b/src/models/ITestResult.ts
@@ -1,4 +1,4 @@
-import { InspectionType, SectionIVA } from '@dvsa/cvs-type-definitions/types/iva/defects/get';
+import {InspectionType} from '@dvsa/cvs-type-definitions/types/iva/defects/get';
 
 export interface ITestResult {
   testResultId: string;
@@ -102,9 +102,9 @@ export interface Defect {
   prohibitionIssued?: boolean;
 }
 
-export interface DefectIVA{
+export interface DefectIVA {
   sectionNumber: string;
-  sectionDescription: string;  
+  sectionDescription: string;
   rsNumber: number;
   requiredStandard: string;
   refCalculation: string;

--- a/src/models/validators/CommonSchema.ts
+++ b/src/models/validators/CommonSchema.ts
@@ -93,7 +93,7 @@ export const ivaDefectSchema = Joi.object({
     .min(1)
     .max(2)
     .required(),
-  prs: Joi.boolean().required()
+  prs: Joi.boolean().required(),
 });
 
 export const defectsCommonSchema = Joi.object().keys({

--- a/src/models/validators/CommonSchema.ts
+++ b/src/models/validators/CommonSchema.ts
@@ -79,7 +79,7 @@ const baseTestTypesCommonSchema = Joi.object().keys({
 export const ivaDefectSchema = Joi.object({
   sectionNumber: Joi.string().required(),
   sectionDescription: Joi.string().required(),
-  additionalNotes: Joi.string().optional(),
+  additionalNotes: Joi.string().allow('', null).optional(),
   rsNumber: Joi.number().required(),
   requiredStandard: Joi.string().required(),
   refCalculation: Joi.string().required(),

--- a/src/models/validators/CommonSchema.ts
+++ b/src/models/validators/CommonSchema.ts
@@ -79,28 +79,21 @@ const baseTestTypesCommonSchema = Joi.object().keys({
 export const ivaDefectSchema = Joi.object({
   sectionNumber: Joi.string().required(),
   sectionDescription: Joi.string().required(),
-  additionalInformation: Joi.object({
-    notes: Joi.string().required(),
-  }).optional(),
-  requiredStandards: Joi.array()
+  additionalNotes: Joi.string().optional(),
+  rsNumber: Joi.number().required(),
+  requiredStandard: Joi.string().required(),
+  refCalculation: Joi.string().required(),
+  additionalInfo: Joi.boolean().required(),
+  inspectionTypes: Joi.array()
     .items(
-      Joi.object({
-        rsNumber: Joi.number().required(),
-        requiredStandard: Joi.string().required(),
-        refCalculation: Joi.string().required(),
-        additionalInfo: Joi.boolean().required(),
-        inspectionTypes: Joi.array()
-          .items(
-            Joi.string()
-              .valid('basic', 'normal')
-              .error(customInspectionTypesErrorMessage),
-          )
-          .min(1)
-          .max(2)
-          .required(),
-      }),
+      Joi.string()
+        .valid('basic', 'normal')
+        .error(customInspectionTypesErrorMessage),
     )
+    .min(1)
+    .max(2)
     .required(),
+  prs: Joi.boolean().required()
 });
 
 export const defectsCommonSchema = Joi.object().keys({

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3230,6 +3230,35 @@ describe('insertTestResult', () => {
       });
     });
 
+    context(
+      'when creating an IVA failed test record with IVA defects and an empty string for additional notes',
+      () => {
+        it('should create the record successfully', () => {
+          const testResult = {
+            ...testResultsPostMock[13],
+          } as ITestResultPayload;
+          testResult.testTypes.forEach((x) => {
+            x.testTypeId = '125';
+            x.ivaDefects?.push({
+              sectionNumber: '01',
+              sectionDescription: 'Noise',
+              rsNumber: 1,
+              requiredStandard: 'The exhaust must be securely mounted.',
+              refCalculation: '1.1',
+              additionalInfo: true,
+              inspectionTypes: ['basic', 'normal'],
+              prs: false,
+              additionalNotes: '',
+            });
+            return x;
+          });
+          const validationResult =
+            ValidationUtil.validateInsertTestResultPayload(testResult);
+          expect(validationResult).toBe(true);
+        });
+      },
+    );
+
     // TODO COMMENTED OUT UNTIL FEATURE TEAMS COMPLETE IVA DEFECT WORK
     // context(
     //   'when creating an IVA failed test record without IVA defects',

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3214,15 +3214,13 @@ describe('insertTestResult', () => {
           x.ivaDefects?.push({
             sectionNumber: '01',
             sectionDescription: 'Noise',
-            requiredStandards: [
-              {
-                rsNumber: 1,
-                requiredStandard: 'The exhaust must be securely mounted.',
-                refCalculation: '1.1',
-                additionalInfo: true,
-                inspectionTypes: ['basic', 'normal'],
-              },
-            ],
+            rsNumber: 1,
+            requiredStandard: 'The exhaust must be securely mounted.',
+            refCalculation: '1.1',
+            additionalInfo: true,
+            inspectionTypes: ['basic', 'normal'],
+            prs: false,
+            additionalNotes: 'the exhaust was loose',
           });
           return x;
         });

--- a/tests/unit/updateTestResults.unitTest.ts
+++ b/tests/unit/updateTestResults.unitTest.ts
@@ -853,15 +853,12 @@ describe('updateTestResults', () => {
             {
               sectionNumber: '01',
               sectionDescription: 'Noise',
-              requiredStandards: [
-                {
-                  rsNumber: 1,
-                  requiredStandard: 'The exhaust must be securely mounted.',
-                  refCalculation: '1.1',
-                  additionalInfo: true,
-                  inspectionTypes: ['basic', 'normal'],
-                },
-              ],
+              rsNumber: 1,
+              requiredStandard: 'The exhaust must be securely mounted.',
+              refCalculation: '1.1',
+              additionalInfo: true,
+              inspectionTypes: ['basic', 'normal'],
+              prs: false,
             },
           ];
           x.testTypeClassification = 'Annual With Certificate';
@@ -943,15 +940,12 @@ describe('updateTestResults', () => {
             {
               sectionNumber: '01',
               sectionDescription: 'Noise',
-              requiredStandards: [
-                {
-                  rsNumber: 1,
-                  requiredStandard: 'The exhaust must be securely mounted.',
-                  refCalculation: '1.1',
-                  additionalInfo: true,
-                  inspectionTypes: ['basic', 'normal'],
-                },
-              ],
+              rsNumber: 1,
+              requiredStandard: 'The exhaust must be securely mounted.',
+              refCalculation: '1.1',
+              additionalInfo: true,
+              inspectionTypes: ['basic', 'normal'],
+              prs: false,
             },
           ];
           x.testTypeClassification = 'Annual With Certificate';


### PR DESCRIPTION
## [Ticket title](cb2-10476: Allow Additional Information and PRS to be set per Required Standards)

refactor post request to follow new contract. This allows PRS status and additional notes to be set at the defect level.
[CB2-10476](https://dvsa.atlassian.net/browse/CB2-10476)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
