### PR TITLE
CB2-10828: Refactor test-results service from ivaDefects to requiredStandards

### DIFF
--- a/docs/test-results-api.yml
+++ b/docs/test-results-api.yml
@@ -631,8 +631,8 @@ components:
 
         defects:
           $ref: '#/components/schemas/defects'
-        ivaDefects:
-          $ref: '#/components/schemas/ivaDefects'
+        requiredStandards:
+          $ref: '#/components/schemas/requiredStandards'
         customDefects:
           $ref: '#/components/schemas/customDefects'
     defects:
@@ -769,12 +769,12 @@ components:
           type: string
           maxLength: 200
           nullable: true
-    ivaDefects:
+    requiredStandards:
       type: array
       nullable: true
       items:
-        $ref: '#/components/schemas/ivaDefect'
-    ivaDefect:
+        $ref: '#/components/schemas/requiredStandard'
+    requiredStandard:
       type: object
       properties:
         sectionNumber:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@dvsa/cvs-type-definitions": "4.4.1",
+        "@dvsa/cvs-type-definitions": "6.0.0",
         "aws-lambda": "^1.0.7",
         "aws-sdk": "^2.1354.0",
         "aws-xray-sdk": "^3.3.4",
@@ -1339,9 +1339,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-4.4.1.tgz",
-      "integrity": "sha512-8p0W0BumeUk8dmyNA3mt2NmzUQQrfzLieo5X/6IP308XvCv9wMAG7jMlMYg3eOim4enDaxcT88B7SKY0SMkpgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-6.0.0.tgz",
+      "integrity": "sha512-jRPP2+J7ZWPUaSvHIaEjs6S2wO2Jd2SSAvEgGoVxKYZAmY0eyu6mIRXdhf2aRLAVXWsI/k4QLOr3ulE7ucUtZg==",
       "dependencies": {
         "ajv": "^8.12.0",
         "json-schema-deref-sync": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@dvsa/cvs-type-definitions": "4.4.1",
+    "@dvsa/cvs-type-definitions": "6.0.0",
     "aws-lambda": "^1.0.7",
     "aws-sdk": "^2.1354.0",
     "aws-xray-sdk": "^3.3.4",

--- a/src/models/ITestResult.ts
+++ b/src/models/ITestResult.ts
@@ -70,7 +70,7 @@ export interface TestType {
   seatbeltInstallationCheckDate?: boolean | null; // mandatory for PSV only, not applicable for HGV and TRL
   additionalNotesRecorded: string;
   defects: Defect[];
-  ivaDefects?: DefectIVA[];
+  requiredStandards?: DefectIVA[];
   name: string;
   certificateLink?: string | null; // Not sent from FE, calculated in the BE.
   testTypeClassification?: string; // field not present in API specs and is removed during POST but present in all json objects

--- a/src/models/ITestResult.ts
+++ b/src/models/ITestResult.ts
@@ -70,7 +70,7 @@ export interface TestType {
   seatbeltInstallationCheckDate?: boolean | null; // mandatory for PSV only, not applicable for HGV and TRL
   additionalNotesRecorded: string;
   defects: Defect[];
-  requiredStandards?: DefectRequiredStandard[];
+  requiredStandards?: RequiredStandard[];
   name: string;
   certificateLink?: string | null; // Not sent from FE, calculated in the BE.
   testTypeClassification?: string; // field not present in API specs and is removed during POST but present in all json objects
@@ -105,7 +105,7 @@ export interface Defect {
   prohibitionIssued?: boolean;
 }
 
-export interface DefectRequiredStandard {
+export interface RequiredStandard {
   sectionNumber: string;
   sectionDescription: string;
   rsNumber: number;

--- a/src/models/ITestResult.ts
+++ b/src/models/ITestResult.ts
@@ -1,4 +1,4 @@
-import { InspectionType } from '@dvsa/cvs-type-definitions/types/iva/defects/get';
+import { InspectionType } from '@dvsa/cvs-type-definitions/types/required-standards/defects/get';
 
 export interface ITestResult {
   testResultId: string;

--- a/src/models/ITestResult.ts
+++ b/src/models/ITestResult.ts
@@ -70,7 +70,7 @@ export interface TestType {
   seatbeltInstallationCheckDate?: boolean | null; // mandatory for PSV only, not applicable for HGV and TRL
   additionalNotesRecorded: string;
   defects: Defect[];
-  requiredStandards?: DefectIVA[];
+  requiredStandards?: DefectRequiredStandard[];
   name: string;
   certificateLink?: string | null; // Not sent from FE, calculated in the BE.
   testTypeClassification?: string; // field not present in API specs and is removed during POST but present in all json objects
@@ -105,7 +105,7 @@ export interface Defect {
   prohibitionIssued?: boolean;
 }
 
-export interface DefectIVA {
+export interface DefectRequiredStandard {
   sectionNumber: string;
   sectionDescription: string;
   rsNumber: number;

--- a/src/models/validators/CommonSchema.ts
+++ b/src/models/validators/CommonSchema.ts
@@ -76,7 +76,7 @@ const baseTestTypesCommonSchema = Joi.object().keys({
   particulateTrapFitted: Joi.string().max(100).allow(null),
 });
 
-export const ivaDefectSchema = Joi.object({
+export const requiredStandardsSchema = Joi.object({
   sectionNumber: Joi.string().required(),
   sectionDescription: Joi.string().required(),
   additionalNotes: Joi.string().allow('', null).optional(),

--- a/src/models/validators/SpecialistTestsCommonSchemaCancelled.ts
+++ b/src/models/validators/SpecialistTestsCommonSchemaCancelled.ts
@@ -3,7 +3,7 @@ import {
   defectsCommonSchema,
   testResultsCommonSchema,
   testTypesSpecialistSchema,
-  ivaDefectSchema,
+  requiredStandardsSchema,
 } from './CommonSchema';
 
 export const defectsCommonSchemaSpecialistTestsCancelled =
@@ -41,7 +41,7 @@ export const testTypesCommonSchemaSpecialistTestsCancelled =
     defects: Joi.array()
       .items(defectsCommonSchemaSpecialistTestsCancelled)
       .required(),
-    ivaDefects: Joi.array().items(ivaDefectSchema.required()).optional(),
+    requiredStandards: Joi.array().items(requiredStandardsSchema.required()).optional(),
   });
 
 export const testResultsCommonSchemaSpecialistTestsCancelled =

--- a/src/models/validators/SpecialistTestsCommonSchemaSubmitted.ts
+++ b/src/models/validators/SpecialistTestsCommonSchemaSubmitted.ts
@@ -1,16 +1,16 @@
 import * as Joi from 'joi';
 import {
   defectsCommonSchema,
-  ivaDefectSchema,
+  requiredStandardsSchema,
   testResultsCommonSchema,
   testTypesSpecialistSchema,
 } from './CommonSchema';
 
-export const testTypesIVADefectCommonSchemaSpecialistTestsSubmitted =
+export const testTypesRequiredStandardCommonSchemaSpecialistTestsSubmitted =
   testTypesSpecialistSchema.keys({
     testTypeEndTimestamp: Joi.date().iso().required(),
     testResult: Joi.any().only(['fail', 'pass', 'prs', 'abandoned']).required(),
-    ivaDefects: Joi.array().items(ivaDefectSchema.required()).optional(),
+    requiredStandards: Joi.array().items(requiredStandardsSchema.required()).optional(),
   });
 
 export const defectsCommonSchemaSpecialistTestsSubmitted =
@@ -51,7 +51,7 @@ export const testTypesCommonSchemaSpecialistTestsSubmitted =
     defects: Joi.array()
       .items(defectsCommonSchemaSpecialistTestsSubmitted)
       .required(),
-    ivaDefects: Joi.array().items(ivaDefectSchema).optional(),
+    requiredStandards: Joi.array().items(requiredStandardsSchema).optional(),
   });
 
 export const testResultsCommonSchemaSpecialistTestsSubmitted =

--- a/src/models/validators/TestResultsSchemaCarSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaCarSubmitted.ts
@@ -4,7 +4,7 @@ import {
   testResultsCommonSchemaSpecialistTestsSubmitted,
   testTypesCommonSchemaSpecialistTestsSubmitted,
 } from './SpecialistTestsCommonSchemaSubmitted';
-import { ivaDefectSchema } from './CommonSchema';
+import { requiredStandardsSchema } from './CommonSchema';
 
 export const carSubmitted =
   testResultsCommonSchemaSpecialistTestsSubmitted.keys({
@@ -15,7 +15,7 @@ export const carSubmitted =
           defects: array()
             .items(defectsCommonSchemaSpecialistTestsSubmitted)
             .optional(),
-          ivaDefects: array().items(ivaDefectSchema.required()).optional(),
+          requiredStandards: array().items(requiredStandardsSchema.required()).optional(),
         }),
       )
       .required(),

--- a/src/models/validators/TestResultsSchemaHGVCancelled.ts
+++ b/src/models/validators/TestResultsSchemaHGVCancelled.ts
@@ -4,7 +4,7 @@ import {
   defectsCommonSchema,
   testTypesCommonSchema,
   testResultsCommonSchema,
-  ivaDefectSchema,
+  requiredStandardsSchema,
 } from './CommonSchema';
 
 const defectsSchema = defectsCommonSchema.keys({
@@ -35,7 +35,7 @@ const testTypesSchema = testTypesCommonSchema.keys({
     .allow(null),
   testTypeEndTimestamp: Joi.date().iso().required().allow(null),
   defects: Joi.array().items(defectsSchema).required(),
-  ivaDefects: array().items(ivaDefectSchema.required()).optional(),
+  requiredStandards: array().items(requiredStandardsSchema.required()).optional(),
 });
 
 export const hgvCancelled = testResultsCommonSchema.keys({

--- a/src/models/validators/TestResultsSchemaHGVSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaHGVSubmitted.ts
@@ -4,7 +4,7 @@ import {
   defectsCommonSchema,
   testTypesCommonSchema,
   testResultsCommonSchema,
-  ivaDefectSchema,
+  requiredStandardsSchema,
 } from './CommonSchema';
 
 const defectsSchema = defectsCommonSchema.keys({
@@ -38,7 +38,7 @@ const testTypesSchema = testTypesCommonSchema.keys({
   testTypeEndTimestamp: Joi.date().iso().required(),
   testResult: Joi.any().only(['fail', 'pass', 'prs', 'abandoned']).required(),
   defects: Joi.array().items(defectsSchema).required(),
-  ivaDefects: array().items(ivaDefectSchema.required()).optional(),
+  requiredStandards: array().items(requiredStandardsSchema.required()).optional(),
 });
 
 export const hgvSubmitted = testResultsCommonSchema.keys({

--- a/src/models/validators/TestResultsSchemaLGVSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaLGVSubmitted.ts
@@ -4,7 +4,7 @@ import {
   testResultsCommonSchemaSpecialistTestsSubmitted,
   testTypesCommonSchemaSpecialistTestsSubmitted,
 } from './SpecialistTestsCommonSchemaSubmitted';
-import { ivaDefectSchema } from './CommonSchema';
+import { requiredStandardsSchema } from './CommonSchema';
 
 export const lgvSubmitted =
   testResultsCommonSchemaSpecialistTestsSubmitted.keys({
@@ -17,7 +17,7 @@ export const lgvSubmitted =
             .optional(),
         }),
         testTypesCommonSchemaSpecialistTestsSubmitted.keys({
-          ivaDefects: array().items(ivaDefectSchema.required()).optional(),
+          requiredStandards: array().items(requiredStandardsSchema.required()).optional(),
         }),
       )
       .required(),

--- a/src/models/validators/TestResultsSchemaMotorcycleSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaMotorcycleSubmitted.ts
@@ -4,7 +4,7 @@ import {
   testResultsCommonSchemaSpecialistTestsSubmitted,
   testTypesCommonSchemaSpecialistTestsSubmitted,
 } from './SpecialistTestsCommonSchemaSubmitted';
-import { ivaDefectSchema } from './CommonSchema';
+import { requiredStandardsSchema } from './CommonSchema';
 
 export const motorcycleSubmitted =
   testResultsCommonSchemaSpecialistTestsSubmitted.keys({
@@ -50,7 +50,7 @@ export const motorcycleSubmitted =
           defects: array()
             .items(defectsCommonSchemaSpecialistTestsSubmitted)
             .optional(),
-          ivaDefects: array().items(ivaDefectSchema.required()).optional(),
+          requiredStandards: array().items(requiredStandardsSchema.required()).optional(),
         }),
       )
       .required(),

--- a/src/models/validators/TestResultsSchemaPSVCancelled.ts
+++ b/src/models/validators/TestResultsSchemaPSVCancelled.ts
@@ -4,7 +4,7 @@ import {
   defectsCommonSchema,
   testTypesCommonSchema,
   testResultsCommonSchema,
-  ivaDefectSchema,
+  requiredStandardsSchema,
 } from './CommonSchema';
 
 const defectsSchema = defectsCommonSchema.keys({
@@ -38,7 +38,7 @@ const testTypesSchema = testTypesCommonSchema.keys({
     .required()
     .allow(null),
   defects: Joi.array().items(defectsSchema).required(),
-  ivaDefects: array().items(ivaDefectSchema.required()).optional(),
+  requiredStandards: array().items(requiredStandardsSchema.required()).optional(),
   modType: Joi.object({
     code: Joi.string().only(['p', 'm', 'g']),
     description: Joi.string().only([

--- a/src/models/validators/TestResultsSchemaPSVSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaPSVSubmitted.ts
@@ -4,7 +4,7 @@ import {
   defectsCommonSchema,
   testTypesCommonSchema,
   testResultsCommonSchema,
-  ivaDefectSchema,
+  requiredStandardsSchema,
 } from './CommonSchema';
 
 const defectsSchema = defectsCommonSchema.keys({
@@ -41,7 +41,7 @@ const testTypesSchema = testTypesCommonSchema.keys({
   seatbeltInstallationCheckDate: Joi.boolean().required().allow(null),
   testResult: Joi.any().only(['fail', 'pass', 'prs', 'abandoned']).required(),
   defects: Joi.array().items(defectsSchema).required(),
-  ivaDefects: array().items(ivaDefectSchema.required()).optional(),
+  requiredStandards: array().items(requiredStandardsSchema.required()).optional(),
   modType: Joi.object({
     code: Joi.string().only(['p', 'm', 'g']),
     description: Joi.string().only([

--- a/src/models/validators/TestResultsSchemaTRLCancelled.ts
+++ b/src/models/validators/TestResultsSchemaTRLCancelled.ts
@@ -4,7 +4,7 @@ import {
   defectsCommonSchema,
   testTypesCommonSchema,
   testResultsCommonSchema,
-  ivaDefectSchema,
+  requiredStandardsSchema,
 } from './CommonSchema';
 
 const defectsSchema = defectsCommonSchema.keys({
@@ -35,7 +35,7 @@ const testTypesSchema = testTypesCommonSchema.keys({
     .required()
     .allow(null),
   defects: Joi.array().items(defectsSchema).required(),
-  ivaDefects: array().items(ivaDefectSchema.required()).optional(),
+  requiredStandards: array().items(requiredStandardsSchema.required()).optional(),
 });
 
 export const trlCancelled = testResultsCommonSchema.keys({

--- a/src/models/validators/TestResultsSchemaTRLSubmitted.ts
+++ b/src/models/validators/TestResultsSchemaTRLSubmitted.ts
@@ -4,7 +4,7 @@ import {
   defectsCommonSchema,
   testTypesCommonSchema,
   testResultsCommonSchema,
-  ivaDefectSchema,
+  requiredStandardsSchema,
 } from './CommonSchema';
 
 const defectsSchema = defectsCommonSchema.keys({
@@ -39,7 +39,7 @@ const testTypesSchema = testTypesCommonSchema.keys({
   testResult: Joi.any().only(['fail', 'pass', 'prs', 'abandoned']).required(),
   testExpiryDate: Joi.date().iso().allow(null, ''),
   defects: Joi.array().items(defectsSchema).required(),
-  ivaDefects: array().items(ivaDefectSchema.required()).optional(),
+  requiredStandards: array().items(requiredStandardsSchema.required()).optional(),
 });
 
 export const trlSubmitted = testResultsCommonSchema.keys({

--- a/src/models/validators/test-types/testTypesSchemaDeskBasedTestsPut.ts
+++ b/src/models/validators/test-types/testTypesSchemaDeskBasedTestsPut.ts
@@ -15,7 +15,7 @@ export const testTypesCommonSchemaDeskBasedTests = Joi.object().keys({
   certificateLink: Joi.string().optional(),
   testTypeClassification: Joi.string().required().allow('', null),
   defects: Joi.array().max(0).allow(null),
-  ivaDefects: Joi.array().max(0).allow(null),
+  requiredStandards: Joi.array().max(0).allow(null),
   customDefects: Joi.array().max(0).allow(null),
 });
 

--- a/src/models/validators/test-types/testTypesSchemaDeskBasedTestsPut.ts
+++ b/src/models/validators/test-types/testTypesSchemaDeskBasedTestsPut.ts
@@ -1,4 +1,5 @@
 import * as Joi from 'joi';
+import {requiredStandardsSchema} from "../CommonSchema";
 
 export const testTypesCommonSchemaDeskBasedTests = Joi.object().keys({
   name: Joi.string(),
@@ -15,7 +16,7 @@ export const testTypesCommonSchemaDeskBasedTests = Joi.object().keys({
   certificateLink: Joi.string().optional(),
   testTypeClassification: Joi.string().required().allow('', null),
   defects: Joi.array().max(0).allow(null),
-  requiredStandards: Joi.array().max(0).allow(null),
+  requiredStandards: Joi.array().items(requiredStandardsSchema.required()).optional(),
   customDefects: Joi.array().max(0).allow(null),
 });
 

--- a/src/models/validators/test-types/testTypesSchemaPut.ts
+++ b/src/models/validators/test-types/testTypesSchemaPut.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-import { defectsCommonSchema, ivaDefectSchema } from '../CommonSchema';
+import { defectsCommonSchema, requiredStandardsSchema } from '../CommonSchema';
 
 const additionalInformationSchema = Joi.object().keys({
   location: Joi.object()
@@ -75,7 +75,7 @@ export const testTypesGroup1 = testTypesCommonSchema.keys({
   lastSeatbeltInstallationCheckDate: Joi.date().required().allow(null),
   seatbeltInstallationCheckDate: Joi.boolean().required().allow(null),
   defects: Joi.array().items(defectsSchemaPut).required(),
-  ivaDefects: Joi.array().items(ivaDefectSchema.required()).optional(),
+  requiredStandards: Joi.array().items(requiredStandardsSchema.required()).optional(),
 });
 
 export const testTypesGroup2 = testTypesCommonSchema.keys({
@@ -83,7 +83,7 @@ export const testTypesGroup2 = testTypesCommonSchema.keys({
   lastSeatbeltInstallationCheckDate: Joi.date().required().allow(null),
   seatbeltInstallationCheckDate: Joi.boolean().required().allow(null),
   defects: Joi.array().items(defectsSchemaPut).required(),
-  ivaDefects: Joi.array().items(ivaDefectSchema.required()).optional(),
+  requiredStandards: Joi.array().items(requiredStandardsSchema.required()).optional(),
 });
 
 export const testTypesGroup3And4And8 = testTypesCommonSchema.keys({
@@ -98,7 +98,7 @@ export const testTypesGroup5And13 = testTypesCommonSchema.keys({
 export const testTypesGroup6And11 = testTypesCommonSchema.keys({
   certificateNumber: Joi.string().required().allow('', null),
   defects: Joi.array().items(defectsSchemaPut).required(),
-  ivaDefects: Joi.array().items(ivaDefectSchema.required()).optional(),
+  requiredStandards: Joi.array().items(requiredStandardsSchema.required()).optional(),
 });
 
 export const testTypesGroup7 = testTypesCommonSchema.keys({
@@ -112,12 +112,12 @@ export const testTypesGroup9And10 = testTypesCommonSchema.keys({
   testExpiryDate: Joi.date().iso().allow(null, ''),
   testAnniversaryDate: Joi.date().iso().required().allow(null, ''),
   defects: Joi.array().items(defectsSchemaPut).required(),
-  ivaDefects: Joi.array().items(ivaDefectSchema.required()).optional(),
+  requiredStandards: Joi.array().items(requiredStandardsSchema.required()).optional(),
 });
 
 export const testTypesGroup12And14 = testTypesCommonSchema.keys({
   defects: Joi.array().items(defectsSchemaPut).required(),
-  ivaDefects: Joi.array().items(ivaDefectSchema.required()).optional(),
+  requiredStandards: Joi.array().items(requiredStandardsSchema.required()).optional(),
 });
 
 export const testTypesGroup15And16 = testTypesCommonSchema.keys({

--- a/src/models/validators/test-types/testTypesSchemaSpecialistTestsPut.ts
+++ b/src/models/validators/test-types/testTypesSchemaSpecialistTestsPut.ts
@@ -1,6 +1,6 @@
 import * as Joi from 'joi';
 import { defectsCommonSchemaSpecialistTestsSubmitted } from '../SpecialistTestsCommonSchemaSubmitted';
-import { ivaDefectSchema } from '../CommonSchema';
+import { requiredStandardsSchema } from '../CommonSchema';
 
 export const testTypesCommonSchemaSpecialistTests = Joi.object()
   .keys({
@@ -46,7 +46,7 @@ export const testTypesSpecialistGroup1 =
     defects: Joi.array()
       .items(defectsCommonSchemaSpecialistTestsSubmitted)
       .optional(),
-    ivaDefects: Joi.array().items(ivaDefectSchema.required()).optional(),
+    requiredStandards: Joi.array().items(requiredStandardsSchema.required()).optional(),
   });
 
 export const testTypesSpecialistGroup2 =
@@ -106,5 +106,5 @@ export const testTypesSpecialistGroup5 =
     defects: Joi.array()
       .items(defectsCommonSchemaSpecialistTestsSubmitted)
       .optional(),
-    ivaDefects: Joi.array().items(ivaDefectSchema.required()).optional(),
+    requiredStandards: Joi.array().items(requiredStandardsSchema.required()).optional(),
   });

--- a/src/utils/mappingUtil.ts
+++ b/src/utils/mappingUtil.ts
@@ -125,7 +125,7 @@ export class MappingUtil {
       if (enums.SPECIALIST_TEST_TYPE_IDS.includes(testType.testTypeId)) {
         testType.defects = [];
       } else {
-        testType.ivaDefects = [];
+        testType.requiredStandards = [];
       }
     });
   }

--- a/src/utils/validationUtil.ts
+++ b/src/utils/validationUtil.ts
@@ -563,7 +563,7 @@ export class ValidationUtil {
     const allFailWithoutDefects = testTypes.every(
       (test) =>
         test.testResult === 'fail' &&
-        (test.ivaDefects?.length === 0 || test.ivaDefects === undefined),
+        (test.requiredStandards?.length === 0 || test.requiredStandards === undefined),
     );
 
     //   if (allFailWithoutDefects) {

--- a/tests/resources/test-results-post.json
+++ b/tests/resources/test-results-post.json
@@ -1055,7 +1055,7 @@
           }
         ],
         "defects": [],
-        "ivaDefects": []
+        "requiredStandards": []
       }
     ],
     "testStationName": "Abshire-Kub",

--- a/tests/resources/test-results.json
+++ b/tests/resources/test-results.json
@@ -5956,7 +5956,7 @@
         "additionalNotesRecorded": null,
         "testTypeId": "175",
         "name": "Specialist test",
-        "ivaDefect": [],
+        "requiredStandards": [],
         "createdAt": "2022-11-11T00:52:16.203Z",
         "lastUpdatedAt": "2022-11-11T00:52:16.203Z",
         "testTypeClassification": "Annual With Certificate",

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3376,7 +3376,7 @@ describe('insertTestResult', () => {
 
           testResult.testTypes.forEach((x) => {
             x.testTypeId = '125';
-            x.ivaDefects?.push({
+            x.requiredStandards?.push({
               sectionNumber: '01',
               sectionDescription: 'Noise',
               rsNumber: 1,
@@ -3407,7 +3407,7 @@ describe('insertTestResult', () => {
 
           testResult.testTypes.forEach((x) => {
             x.testTypeId = '125';
-            x.ivaDefects?.push({
+            x.requiredStandards?.push({
               sectionNumber: '01',
               sectionDescription: 'Noise',
               rsNumber: 1,
@@ -3439,7 +3439,7 @@ describe('insertTestResult', () => {
 
           testResult.testTypes.forEach((x) => {
             x.testTypeId = '125';
-            x.ivaDefects?.push({
+            x.requiredStandards?.push({
               sectionNumber: '01',
               sectionDescription: 'Noise',
               rsNumber: 1,
@@ -3471,7 +3471,7 @@ describe('insertTestResult', () => {
 
           testResult.testTypes.forEach((x) => {
             x.testTypeId = '125';
-            x.ivaDefects?.push({
+            x.requiredStandards?.push({
               sectionNumber: '01',
               sectionDescription: 'Noise',
               rsNumber: 1,
@@ -3503,7 +3503,7 @@ describe('insertTestResult', () => {
 
           testResult.testTypes.forEach((x) => {
             x.testTypeId = '125';
-            x.ivaDefects?.push({
+            x.requiredStandards?.push({
               sectionNumber: '01',
               sectionDescription: 'Noise',
               rsNumber: 1,

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3211,7 +3211,7 @@ describe('insertTestResult', () => {
         const testResult = { ...testResultsPostMock[13] } as ITestResultPayload;
         testResult.testTypes.forEach((x) => {
           x.testTypeId = '125';
-          x.ivaDefects?.push({
+          x.requiredStandards?.push({
             sectionNumber: '01',
             sectionDescription: 'Noise',
             rsNumber: 1,
@@ -3239,7 +3239,7 @@ describe('insertTestResult', () => {
           } as ITestResultPayload;
           testResult.testTypes.forEach((x) => {
             x.testTypeId = '125';
-            x.ivaDefects?.push({
+            x.requiredStandards?.push({
               sectionNumber: '01',
               sectionDescription: 'Noise',
               rsNumber: 1,
@@ -3281,7 +3281,7 @@ describe('insertTestResult', () => {
     context('when creating a non IVA test record without IVA defects', () => {
       it('should create the record successfully', () => {
         const testResult = { ...testResultsPostMock[13] } as ITestResultPayload;
-        testResult.testTypes.forEach((x) => delete x.ivaDefects);
+        testResult.testTypes.forEach((x) => delete x.requiredStandards);
         const validationResult =
           ValidationUtil.validateInsertTestResultPayload(testResult);
         expect(validationResult).toBe(true);
@@ -3294,7 +3294,7 @@ describe('insertTestResult', () => {
         testResult.testTypes.forEach((x) => {
           x.testTypeId = '142';
           x.testTypeName = 'COIF with annual test';
-          delete x.ivaDefects;
+          delete x.requiredStandards;
           return x;
         });
         const validationResult =

--- a/tests/unit/updateTestResults.unitTest.ts
+++ b/tests/unit/updateTestResults.unitTest.ts
@@ -845,11 +845,11 @@ describe('updateTestResults', () => {
       testToUpdate.testTypes.forEach(modificationCallback);
     };
 
-    context('A failed IVA Test Record with IVA defects', () => {
-      it('can be updated with IVA defects present', async () => {
+    context('A failed IVA Test Record with required standards', () => {
+      it('can be updated with required standards present', async () => {
         setupTestTypes((x) => {
           x.testTypeId = '125';
-          x.ivaDefects = [
+          x.requiredStandards = [
             {
               sectionNumber: '01',
               sectionDescription: 'Noise',
@@ -876,9 +876,9 @@ describe('updateTestResults', () => {
       });
     });
 
-    context('A failed IVA Test Record without IVA defects', () => {
-      it('cannot be updated without IVA defects present', async () => {
-        setupTestTypes((x) => delete x.ivaDefects);
+    context('A failed IVA Test Record without required standards', () => {
+      it('cannot be updated without required standards present', async () => {
+        setupTestTypes((x) => delete x.requiredStandards);
 
         try {
           await testResultsService.updateTestResult(
@@ -894,12 +894,12 @@ describe('updateTestResults', () => {
     });
 
     context('A non-IVA test', () => {
-      it('can be updated without IVA defects present', async () => {
+      it('can be updated without required standards present', async () => {
         setupTestTypes((x) => {
           x.testTypeClassification = 'Annual With Certificate';
           x.testCode = 'cel';
           x.testNumber = '213213123';
-          delete x.ivaDefects;
+          delete x.requiredStandards;
           return x;
         });
 
@@ -913,14 +913,14 @@ describe('updateTestResults', () => {
     });
 
     context('A COIF test', () => {
-      it('can be updated without IVA defects present', async () => {
+      it('can be updated without required standards defects present', async () => {
         setupTestTypes((x) => {
           x.testTypeId = '142';
           x.testTypeName = 'COIF with annual test';
           x.testTypeClassification = 'Annual With Certificate';
           x.testCode = 'cel';
           x.testNumber = '213213123';
-          delete x.ivaDefects;
+          delete x.requiredStandards;
           return x;
         });
         const returnedRecord = await testResultsService.updateTestResult(
@@ -932,11 +932,11 @@ describe('updateTestResults', () => {
       });
     });
 
-    context('When IVA defects are present in the payload', () => {
-      it('IVA defects are not removed', async () => {
+    context('When required standards are present in the payload', () => {
+      it('Required standards are not removed', async () => {
         setupTestTypes((x) => {
           x.testTypeId = '125';
-          x.ivaDefects = [
+          x.requiredStandards = [
             {
               sectionNumber: '01',
               sectionDescription: 'Noise',
@@ -960,18 +960,18 @@ describe('updateTestResults', () => {
           msUserDetails,
         );
         res.testTypes.forEach((testType) =>
-          expect(testType.ivaDefects).toBeDefined(),
+          expect(testType.requiredStandards).toBeDefined(),
         );
       });
     });
 
-    context('When IVA defects are not present in the payload', () => {
-      it('IVA defects are removed', async () => {
+    context('When required standards are not present in the payload', () => {
+      it('Required standards are removed', async () => {
         setupTestTypes((x) => {
           x.testTypeClassification = 'Annual With Certificate';
           x.testCode = 'cel';
           x.testNumber = '213213123';
-          delete x.ivaDefects;
+          delete x.requiredStandards;
         });
         const res: ITestResult = await testResultsService.updateTestResult(
           testToUpdate.systemNumber,
@@ -979,10 +979,10 @@ describe('updateTestResults', () => {
           msUserDetails,
         );
         res.testTypes.forEach((testType) => {
-          const isIvaDefectsRemoved =
-            testType.ivaDefects === undefined ||
-            testType.ivaDefects.length === 0;
-          expect(isIvaDefectsRemoved).toBe(true);
+          const isRequiredStandardsRemoved =
+            testType.requiredStandards === undefined ||
+            testType.requiredStandards.length === 0;
+          expect(isRequiredStandardsRemoved).toBe(true);
         });
       });
     });


### PR DESCRIPTION
## Refactor test-results service from ivaDefects to requiredStandards

Replacing ivaDefects with requiredStandards will allow re-use of the same objects for MSVA as well as IVA.

This also brings terminology in-line with DVSA policy and VTA/VTM apps.

**As per PR comments, it was agreed that the PUT validation for desk based tests should be consistent with the POST, so that was also updated as part of this change.**

[CB2-10828](https://dvsa.atlassian.net/browse/CB2-10828)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
