### PR TITLE
CB2-10932: Reference number optional in the JOI schemas

### DIFF
--- a/src/models/ITestResult.ts
+++ b/src/models/ITestResult.ts
@@ -71,6 +71,7 @@ export interface TestType {
   additionalNotesRecorded: string;
   defects: Defect[];
   requiredStandards?: RequiredStandard[];
+  customDefects?: CustomDefects[];
   name: string;
   certificateLink?: string | null; // Not sent from FE, calculated in the BE.
   testTypeClassification?: string; // field not present in API specs and is removed during POST but present in all json objects
@@ -145,4 +146,10 @@ export interface ModType {
 export interface BodyTypeModel {
   code: string;
   description: string;
+}
+
+export interface CustomDefects {
+  referenceNumber?: string;
+  defectName: string;
+  defectNotes: string;
 }

--- a/src/models/validators/CommonSchema.ts
+++ b/src/models/validators/CommonSchema.ts
@@ -123,7 +123,7 @@ export const testTypesCommonSchema = baseTestTypesCommonSchema.keys({
   customDefects: Joi.array()
     .items(
       Joi.object().keys({
-        referenceNumber: Joi.string().max(10).required(),
+        referenceNumber: Joi.string().max(10).optional(),
         defectName: Joi.string().max(200).required(),
         defectNotes: Joi.string().max(200).required().allow(null),
       }),

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3398,6 +3398,45 @@ describe('insertTestResult', () => {
     );
 
     context(
+      'when creating a test record for an IVA test with make, model and body type and without reference number',
+      () => {
+        it('should create the record successfully', () => {
+          const testResult = {
+            ...testResultsPostMock[13],
+          } as ITestResultPayload;
+
+
+          testResult.testTypes.forEach((x) => {
+            x.testTypeId = '125';
+            x.customDefects = [
+              {
+                defectName: "Some custom defect",
+                defectNotes: "some defect noe"
+              }
+            ]
+            x.requiredStandards?.push({
+              sectionNumber: '01',
+              sectionDescription: 'Noise',
+              rsNumber: 1,
+              requiredStandard: 'The exhaust must be securely mounted.',
+              refCalculation: '1.1',
+              additionalInfo: true,
+              inspectionTypes: ['basic', 'normal'],
+              prs: false,
+              additionalNotes: '',
+            });
+
+            return x;
+          });
+
+          const validationResult =
+            ValidationUtil.validateInsertTestResultPayload(testResult);
+          expect(validationResult).toBe(true);
+        });
+      },
+    );
+
+    context(
       'when creating a test record for an IVA test with a missing make',
       () => {
         it('should create the record succesfully', () => {


### PR DESCRIPTION
##  ReferenceNumber required when submitting a test with additional defects

This change is to make the reference number optional, instead of required in the 
[CB2-10932](https://dvsa.atlassian.net/browse/CB2-10932)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
