### PR TITLE
feat(cb2-11180): Populate certificate number (with test number) for failed IVA and MSVA tests

### DIFF
--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -91,6 +91,8 @@ export const VEHICLE_TYPES = {
 
 export const TEST_TYPE_CLASSIFICATION = {
   ANNUAL_WITH_CERTIFICATE: 'Annual With Certificate',
+  IVA_WITH_CERTIFICATE: 'IVA With Certificate',
+  MSVA_WITH_CERTIFICATE: 'MSVA With Certificate',
 };
 
 export const TEST_RESULT = {

--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -420,8 +420,9 @@ export class VehicleTestController implements IVehicleTestController {
     vehicleType: string,
   ): boolean {
     if (
-      testType.testTypeClassification ===
-        enums.TEST_TYPE_CLASSIFICATION.ANNUAL_WITH_CERTIFICATE &&
+      (testType.testTypeClassification ===
+        enums.TEST_TYPE_CLASSIFICATION.ANNUAL_WITH_CERTIFICATE ||
+        this.isSpecialistTestWithoutCertificateNumber(testType)) &&
       testType.testResult !== enums.TEST_RESULT.ABANDONED
     ) {
       if (
@@ -443,5 +444,17 @@ export class VehicleTestController implements IVehicleTestController {
       return true;
     }
     return false;
+  }
+
+  private static isSpecialistTestWithoutCertificateNumber(
+    testType: models.TestType,
+  ): boolean {
+    return (
+      (testType.testTypeClassification ===
+        enums.TEST_TYPE_CLASSIFICATION.IVA_WITH_CERTIFICATE ||
+        testType.testTypeClassification ===
+          enums.TEST_TYPE_CLASSIFICATION.MSVA_WITH_CERTIFICATE) &&
+      (!testType.certificateNumber || testType.certificateNumber === '')
+    );
   }
 }

--- a/tests/resources/test-results-post.json
+++ b/tests/resources/test-results-post.json
@@ -1017,7 +1017,7 @@
     ],
     "make": "test make",
     "model": "test model",
-    "bodyType": { "code": "test code", "description": "test description"}
+    "bodyType": { "code": "test code", "description": "test description" }
   },
   {
     "vin": "1B7GG36N12S678410",
@@ -1085,6 +1085,74 @@
     "reasonForCancellation": null,
     "make": "test make",
     "model": "test model",
-    "bodyType": { "code": "test code", "description": "test description"}
+    "bodyType": { "code": "test code", "description": "test description" }
+  },
+  {
+    "vin": "1B7GG36N12S678410",
+    "vrm": "BQ91YHQ",
+    "countryOfRegistration": "gb",
+    "euVehicleCategory": "l1e-a",
+    "odometerReading": 22222,
+    "odometerReadingUnits": "kilometres",
+    "preparerName": null,
+    "preparerId": "No preparer ID given",
+    "createdAt": "2022-11-11T00:52:16.000",
+    "testStartTimestamp": "2022-11-11T00:51:39.000",
+    "testTypes": [
+      {
+        "testResult": "fail",
+        "reasonForAbandoning": null,
+        "additionalCommentsForAbandon": null,
+        "testTypeName": "Full MSVA moped vehicle inspection",
+        "secondaryCertificateNumber": null,
+        "testTypeStartTimestamp": "2022-11-11T00:51:39.000",
+        "testTypeEndTimestamp": "2022-11-11T00:52:15.000",
+        "prohibitionIssued": false,
+        "seatbeltInstallationCheckDate": true,
+        "numberOfSeatbeltsFitted": 8,
+        "lastSeatbeltInstallationCheckDate": "2022-10-10T00:00:00.000",
+        "additionalNotesRecorded": null,
+        "testTypeId": "175",
+        "name": "Specialist test",
+        "certificateNumber": null,
+        "customDefects": [
+          {
+            "referenceNumber": "ref",
+            "defectName": "name",
+            "defectNotes": "notes"
+          }
+        ],
+        "defects": [],
+        "requiredStandards": []
+      }
+    ],
+    "testStationName": "Abshire-Kub",
+    "testStationPNumber": "09-4129632",
+    "testStationType": "gvts",
+    "testerStaffId": "10000009",
+    "testerName": "CVS Automation9",
+    "testerEmailAddress": "CVS.Automation9@dvsatest-cloud.uk",
+    "reasonForCreation": "reasonb",
+    "testResultId": "7c968a55-5da5-414d-863a-ba5997a327fc",
+    "vehicleType": "psv",
+    "testStatus": "submitted",
+    "systemNumber": "11000002",
+    "testEndTimestamp": "2022-11-11T00:52:14.616Z",
+    "vehicleClass": {
+      "code": "s",
+      "description": "small psv (ie: less than or equal to 22 seats)"
+    },
+    "noOfAxles": 2,
+    "numberOfWheelsDriven": null,
+    "regnDate": "2011-01-05",
+    "createdByName": "CVS Automation9",
+    "createdById": "10000009",
+    "numberOfSeats": 50,
+    "vehicleConfiguration": "rigid",
+    "vehicleSize": "small",
+    "reasonForCancellation": null,
+    "make": "test make",
+    "model": "test model",
+    "bodyType": { "code": "test code", "description": "test description" }
   }
 ]

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3405,15 +3405,14 @@ describe('insertTestResult', () => {
             ...testResultsPostMock[13],
           } as ITestResultPayload;
 
-
           testResult.testTypes.forEach((x) => {
             x.testTypeId = '125';
             x.customDefects = [
               {
-                defectName: "Some custom defect",
-                defectNotes: "some defect noe"
-              }
-            ]
+                defectName: 'Some custom defect',
+                defectNotes: 'some defect noe',
+              },
+            ];
             x.requiredStandards?.push({
               sectionNumber: '01',
               sectionDescription: 'Noise',
@@ -3560,6 +3559,386 @@ describe('insertTestResult', () => {
           const validationResult =
             ValidationUtil.validateInsertTestResultPayload(testResult);
           expect(validationResult).toBe(true);
+        });
+      },
+    );
+
+    context(
+      'when creating a test record for an IVA test with no certificate number',
+      () => {
+        it('should create the record succesfully and the certificate number should match the test number', () => {
+          const testResult = cloneDeep(testResultsPostMock[13]);
+          testResult.testTypes[0].testTypeId = '125';
+          testResult.testTypes[0].requiredStandards?.push({
+            sectionNumber: '01',
+            sectionDescription: 'Noise',
+            rsNumber: 1,
+            requiredStandard: 'The exhaust must be securely mounted.',
+            refCalculation: '1.1',
+            additionalInfo: true,
+            inspectionTypes: [],
+            prs: false,
+            additionalNotes: '',
+          });
+          MockTestResultsDAO = jest.fn().mockImplementation(() => ({
+            createSingle: () =>
+              Promise.resolve({
+                Attributes: Array.of(testResult),
+              }),
+            createTestNumber: () =>
+              Promise.resolve({
+                testNumber: 'W01A00209',
+                id: 'W01',
+                certLetter: 'A',
+                sequenceNumber: '002',
+              }),
+            getTestCodesAndClassificationFromTestTypes: () =>
+              Promise.resolve({
+                linkedTestCode: null,
+                defaultTestCode: 'qjt1',
+                testTypeClassification: 'IVA With Certificate',
+              }),
+            getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
+          }));
+
+          testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+          expect.assertions(2);
+          return testResultsService
+            .insertTestResult(testResult)
+            .then((insertedTestResult: any) => {
+              expect(insertedTestResult[0].testTypes[0].testTypeId).toBe('125');
+              expect(insertedTestResult[0].testTypes[0].certificateNumber).toBe(
+                'W01A00209',
+              );
+            });
+        });
+      },
+    );
+
+    context(
+      'when creating a test record for an IVA test with a certificate number',
+      () => {
+        it('should create the record succesfully and the certificate number should match the one provided', () => {
+          const testResult = cloneDeep(testResultsPostMock[13]);
+          testResult.testTypes[0].testTypeId = '125';
+          testResult.testTypes[0].certificateNumber = '12345';
+          testResult.testTypes[0].requiredStandards?.push({
+            sectionNumber: '01',
+            sectionDescription: 'Noise',
+            rsNumber: 1,
+            requiredStandard: 'The exhaust must be securely mounted.',
+            refCalculation: '1.1',
+            additionalInfo: true,
+            inspectionTypes: [],
+            prs: false,
+            additionalNotes: '',
+          });
+          MockTestResultsDAO = jest.fn().mockImplementation(() => ({
+            createSingle: () =>
+              Promise.resolve({
+                Attributes: Array.of(testResult),
+              }),
+            createTestNumber: () =>
+              Promise.resolve({
+                testNumber: 'W01A00209',
+                id: 'W01',
+                certLetter: 'A',
+                sequenceNumber: '002',
+              }),
+            getTestCodesAndClassificationFromTestTypes: () =>
+              Promise.resolve({
+                linkedTestCode: null,
+                defaultTestCode: 'qjt1',
+                testTypeClassification: 'IVA With Certificate',
+              }),
+            getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
+          }));
+
+          testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+          expect.assertions(2);
+          return testResultsService
+            .insertTestResult(testResult)
+            .then((insertedTestResult: any) => {
+              expect(insertedTestResult[0].testTypes[0].testTypeId).toBe('125');
+              expect(insertedTestResult[0].testTypes[0].certificateNumber).toBe(
+                '12345',
+              );
+            });
+        });
+      },
+    );
+
+    context(
+      'when creating a test record for an IVA test with no certificate number',
+      () => {
+        it('should create the record succesfully and the certificate number should match the test number', () => {
+          const testResult = cloneDeep(testResultsPostMock[13]);
+          testResult.testTypes[0].testTypeId = '125';
+          testResult.testTypes[0].certificateNumber = null;
+          testResult.testTypes[0].requiredStandards?.push({
+            sectionNumber: '01',
+            sectionDescription: 'Noise',
+            rsNumber: 1,
+            requiredStandard: 'The exhaust must be securely mounted.',
+            refCalculation: '1.1',
+            additionalInfo: true,
+            inspectionTypes: [],
+            prs: false,
+            additionalNotes: '',
+          });
+          MockTestResultsDAO = jest.fn().mockImplementation(() => ({
+            createSingle: () =>
+              Promise.resolve({
+                Attributes: Array.of(testResult),
+              }),
+            createTestNumber: () =>
+              Promise.resolve({
+                testNumber: 'W01A00209',
+                id: 'W01',
+                certLetter: 'A',
+                sequenceNumber: '002',
+              }),
+            getTestCodesAndClassificationFromTestTypes: () =>
+              Promise.resolve({
+                linkedTestCode: null,
+                defaultTestCode: 'qjt1',
+                testTypeClassification: 'IVA With Certificate',
+              }),
+            getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
+          }));
+
+          testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+          expect.assertions(2);
+          return testResultsService
+            .insertTestResult(testResult)
+            .then((insertedTestResult: any) => {
+              expect(insertedTestResult[0].testTypes[0].testTypeId).toBe('125');
+              expect(insertedTestResult[0].testTypes[0].certificateNumber).toBe(
+                'W01A00209',
+              );
+            });
+        });
+      },
+    );
+
+    context(
+      'when creating a test record for an IVA test with an empty certificate number',
+      () => {
+        it('should create the record succesfully and the certificate number should match the test number', () => {
+          const testResult = cloneDeep(testResultsPostMock[13]);
+          testResult.testTypes[0].testTypeId = '125';
+          testResult.testTypes[0].certificateNumber = '';
+          testResult.testTypes[0].requiredStandards?.push({
+            sectionNumber: '01',
+            sectionDescription: 'Noise',
+            rsNumber: 1,
+            requiredStandard: 'The exhaust must be securely mounted.',
+            refCalculation: '1.1',
+            additionalInfo: true,
+            inspectionTypes: [],
+            prs: false,
+            additionalNotes: '',
+          });
+          MockTestResultsDAO = jest.fn().mockImplementation(() => ({
+            createSingle: () =>
+              Promise.resolve({
+                Attributes: Array.of(testResult),
+              }),
+            createTestNumber: () =>
+              Promise.resolve({
+                testNumber: 'W01A00209',
+                id: 'W01',
+                certLetter: 'A',
+                sequenceNumber: '002',
+              }),
+            getTestCodesAndClassificationFromTestTypes: () =>
+              Promise.resolve({
+                linkedTestCode: null,
+                defaultTestCode: 'qjt1',
+                testTypeClassification: 'IVA With Certificate',
+              }),
+            getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
+          }));
+
+          testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+          expect.assertions(2);
+          return testResultsService
+            .insertTestResult(testResult)
+            .then((insertedTestResult: any) => {
+              expect(insertedTestResult[0].testTypes[0].testTypeId).toBe('125');
+              expect(insertedTestResult[0].testTypes[0].certificateNumber).toBe(
+                'W01A00209',
+              );
+            });
+        });
+      },
+    );
+
+    context(
+      'when creating a test record for an MSVA test with no certificate number',
+      () => {
+        it('should create the record succesfully and the certificate number should match the test number', () => {
+          const testResult = cloneDeep(testResultsPostMock[13]);
+          testResult.testTypes[0].testTypeId = '133';
+          testResult.testTypes[0].certificateNumber = null;
+          testResult.testTypes[0].requiredStandards?.push({
+            sectionNumber: '4',
+            sectionDescription: 'Speedometer',
+            rsNumber: 1,
+            requiredStandard:
+              'A speedometer; does not indicate speed up to the design speed of the vehicle',
+            refCalculation: '41.1c',
+            additionalInfo: true,
+            inspectionTypes: [],
+            prs: false,
+            additionalNotes: '',
+          });
+          MockTestResultsDAO = jest.fn().mockImplementation(() => ({
+            createSingle: () =>
+              Promise.resolve({
+                Attributes: Array.of(testResult),
+              }),
+            createTestNumber: () =>
+              Promise.resolve({
+                testNumber: 'W01A00209',
+                id: 'W01',
+                certLetter: 'A',
+                sequenceNumber: '002',
+              }),
+            getTestCodesAndClassificationFromTestTypes: () =>
+              Promise.resolve({
+                linkedTestCode: null,
+                defaultTestCode: 'qjt1',
+                testTypeClassification: 'MSVA With Certificate',
+              }),
+            getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
+          }));
+
+          testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+          expect.assertions(2);
+          return testResultsService
+            .insertTestResult(testResult)
+            .then((insertedTestResult: any) => {
+              expect(insertedTestResult[0].testTypes[0].testTypeId).toBe('133');
+              expect(insertedTestResult[0].testTypes[0].certificateNumber).toBe(
+                'W01A00209',
+              );
+            });
+        });
+      },
+    );
+
+    context(
+      'when creating a test record for an MSVA test with an empty certificate number',
+      () => {
+        it('should create the record succesfully and the certificate number should match the test number', () => {
+          const testResult = cloneDeep(testResultsPostMock[13]);
+          testResult.testTypes[0].testTypeId = '133';
+          testResult.testTypes[0].certificateNumber = '';
+          testResult.testTypes[0].requiredStandards?.push({
+            sectionNumber: '4',
+            sectionDescription: 'Speedometer',
+            rsNumber: 1,
+            requiredStandard:
+              'A speedometer; does not indicate speed up to the design speed of the vehicle',
+            refCalculation: '41.1c',
+            additionalInfo: true,
+            inspectionTypes: [],
+            prs: false,
+            additionalNotes: '',
+          });
+          MockTestResultsDAO = jest.fn().mockImplementation(() => ({
+            createSingle: () =>
+              Promise.resolve({
+                Attributes: Array.of(testResult),
+              }),
+            createTestNumber: () =>
+              Promise.resolve({
+                testNumber: 'W01A00209',
+                id: 'W01',
+                certLetter: 'A',
+                sequenceNumber: '002',
+              }),
+            getTestCodesAndClassificationFromTestTypes: () =>
+              Promise.resolve({
+                linkedTestCode: null,
+                defaultTestCode: 'qjt1',
+                testTypeClassification: 'MSVA With Certificate',
+              }),
+            getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
+          }));
+
+          testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+          expect.assertions(2);
+          return testResultsService
+            .insertTestResult(testResult)
+            .then((insertedTestResult: any) => {
+              expect(insertedTestResult[0].testTypes[0].testTypeId).toBe('133');
+              expect(insertedTestResult[0].testTypes[0].certificateNumber).toBe(
+                'W01A00209',
+              );
+            });
+        });
+      },
+    );
+
+    context(
+      'when creating a test record for an MSVA test with a certificate number',
+      () => {
+        it('should create the record succesfully and the certificate number should match the one provided', () => {
+          const testResult = cloneDeep(testResultsPostMock[13]);
+          testResult.testTypes[0].testTypeId = '133';
+          testResult.testTypes[0].certificateNumber = '12345';
+          testResult.testTypes[0].requiredStandards?.push({
+            sectionNumber: '4',
+            sectionDescription: 'Speedometer',
+            rsNumber: 1,
+            requiredStandard:
+              'A speedometer; does not indicate speed up to the design speed of the vehicle',
+            refCalculation: '41.1c',
+            additionalInfo: true,
+            inspectionTypes: [],
+            prs: false,
+            additionalNotes: '',
+          });
+          MockTestResultsDAO = jest.fn().mockImplementation(() => ({
+            createSingle: () =>
+              Promise.resolve({
+                Attributes: Array.of(testResult),
+              }),
+            createTestNumber: () =>
+              Promise.resolve({
+                testNumber: 'W01A00209',
+                id: 'W01',
+                certLetter: 'A',
+                sequenceNumber: '002',
+              }),
+            getTestCodesAndClassificationFromTestTypes: () =>
+              Promise.resolve({
+                linkedTestCode: null,
+                defaultTestCode: 'qjt1',
+                testTypeClassification: 'MSVA With Certificate',
+              }),
+            getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
+          }));
+
+          testResultsService = new TestResultsService(new MockTestResultsDAO());
+
+          expect.assertions(2);
+          return testResultsService
+            .insertTestResult(testResult)
+            .then((insertedTestResult: any) => {
+              expect(insertedTestResult[0].testTypes[0].testTypeId).toBe('133');
+              expect(insertedTestResult[0].testTypes[0].certificateNumber).toBe(
+                '12345',
+              );
+            });
         });
       },
     );

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3671,60 +3671,6 @@ describe('insertTestResult', () => {
     );
 
     context(
-      'when creating a test record for an IVA test with no certificate number',
-      () => {
-        it('should create the record succesfully and the certificate number should match the test number', () => {
-          const testResult = cloneDeep(testResultsPostMock[13]);
-          testResult.testTypes[0].testTypeId = '125';
-          testResult.testTypes[0].certificateNumber = null;
-          testResult.testTypes[0].requiredStandards?.push({
-            sectionNumber: '01',
-            sectionDescription: 'Noise',
-            rsNumber: 1,
-            requiredStandard: 'The exhaust must be securely mounted.',
-            refCalculation: '1.1',
-            additionalInfo: true,
-            inspectionTypes: [],
-            prs: false,
-            additionalNotes: '',
-          });
-          MockTestResultsDAO = jest.fn().mockImplementation(() => ({
-            createSingle: () =>
-              Promise.resolve({
-                Attributes: Array.of(testResult),
-              }),
-            createTestNumber: () =>
-              Promise.resolve({
-                testNumber: 'W01A00209',
-                id: 'W01',
-                certLetter: 'A',
-                sequenceNumber: '002',
-              }),
-            getTestCodesAndClassificationFromTestTypes: () =>
-              Promise.resolve({
-                linkedTestCode: null,
-                defaultTestCode: 'qjt1',
-                testTypeClassification: 'IVA With Certificate',
-              }),
-            getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
-          }));
-
-          testResultsService = new TestResultsService(new MockTestResultsDAO());
-
-          expect.assertions(2);
-          return testResultsService
-            .insertTestResult(testResult)
-            .then((insertedTestResult: any) => {
-              expect(insertedTestResult[0].testTypes[0].testTypeId).toBe('125');
-              expect(insertedTestResult[0].testTypes[0].certificateNumber).toBe(
-                'W01A00209',
-              );
-            });
-        });
-      },
-    );
-
-    context(
       'when creating a test record for an IVA test with an empty certificate number',
       () => {
         it('should create the record succesfully and the certificate number should match the test number', () => {
@@ -3784,7 +3730,6 @@ describe('insertTestResult', () => {
         it('should create the record succesfully and the certificate number should match the test number', () => {
           const testResult = cloneDeep(testResultsPostMock[13]);
           testResult.testTypes[0].testTypeId = '133';
-          testResult.testTypes[0].certificateNumber = null;
           testResult.testTypes[0].requiredStandards?.push({
             sectionNumber: '4',
             sectionDescription: 'Speedometer',


### PR DESCRIPTION
## cb2-11180: Populate certificate number (with test number) for failed IVA and MSVA tests

Adds logic to ensure that IVA and MSVA tests set their cert number as the test number, when a cert number is not provided in the payload
[link to ticket number](https://dvsa.atlassian.net/jira/software/c/projects/CB2/boards/973?selectedIssue=CB2-11180)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
