### PR TITLE
CB2-11930: Amending IVA/MSVA Test Record With Fail Result Causes Certificate Hyperlink Wording to be Replaced by a "Hyphenated" Hyperlink

### DIFF
--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -149,12 +149,14 @@ export class VehicleTestController implements IVehicleTestController {
       }
       // map testTypes back after validation
       payload.testTypes = testTypes;
-      payload.testTypes.forEach(x=>{
-        if(VehicleTestController.isSpecialistTestWithoutCertificateNumber(x)
-          && x.testResult !== enums.TEST_RESULT.ABANDONED){
+      payload.testTypes.forEach((x) => {
+        if (
+          VehicleTestController.isSpecialistTestWithoutCertificateNumber(x) &&
+          x.testResult !== enums.TEST_RESULT.ABANDONED
+        ) {
           x.certificateNumber = x.testNumber;
         }
-      })
+      });
 
       newTestResult = await this.mapOldTestResultToNew(
         systemNumber,

--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -149,6 +149,12 @@ export class VehicleTestController implements IVehicleTestController {
       }
       // map testTypes back after validation
       payload.testTypes = testTypes;
+      payload.testTypes.forEach(x=>{
+        if(VehicleTestController.isSpecialistTestWithoutCertificateNumber(x)
+          && x.testResult !== enums.TEST_RESULT.ABANDONED){
+          x.certificateNumber = x.testNumber;
+        }
+      })
 
       newTestResult = await this.mapOldTestResultToNew(
         systemNumber,

--- a/tests/unit/updateTestResults.unitTest.ts
+++ b/tests/unit/updateTestResults.unitTest.ts
@@ -903,7 +903,9 @@ describe('updateTestResults', () => {
           testToUpdate,
           msUserDetails,
         );
-        expect(returnedRecord.testTypes[0].certificateNumber).toBe('testNumber');
+        expect(returnedRecord.testTypes[0].certificateNumber).toBe(
+          'testNumber',
+        );
       });
     });
 

--- a/tests/unit/updateTestResults.unitTest.ts
+++ b/tests/unit/updateTestResults.unitTest.ts
@@ -876,6 +876,37 @@ describe('updateTestResults', () => {
       });
     });
 
+    context('A failed IVA Test Record with required standards', () => {
+      it('has its certifcate number set to the test number', async () => {
+        setupTestTypes((x) => {
+          x.testTypeId = '125';
+          x.requiredStandards = [
+            {
+              sectionNumber: '01',
+              sectionDescription: 'Noise',
+              rsNumber: 1,
+              requiredStandard: 'This is the new required standard on the test',
+              refCalculation: '1.1',
+              additionalInfo: true,
+              inspectionTypes: ['basic', 'normal'],
+              prs: false,
+            },
+          ];
+          x.testTypeClassification = 'IVA With Certificate';
+          x.testCode = 'cel';
+          x.testNumber = 'testNumber';
+          return x;
+        });
+
+        const returnedRecord = await testResultsService.updateTestResult(
+          testToUpdate.systemNumber,
+          testToUpdate,
+          msUserDetails,
+        );
+        expect(returnedRecord.testTypes[0].certificateNumber).toBe('testNumber');
+      });
+    });
+
     context('A failed IVA Test Record without required standards', () => {
       it('cannot be updated without required standards present', async () => {
         setupTestTypes((x) => delete x.requiredStandards);


### PR DESCRIPTION
## Amending IVA/MSVA Test Record With Fail Result Causes Certificate Hyperlink Wording to be Replaced by a "Hyphenated" Hyperlink

Update test-results to force certificate number to be set on amends to IVA/MSVA tests, when not provided in the payload
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-11930)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
