### PR TITLE
chore(cb2-11271): upgrade cvs-svc-test-results from aws sdk v2 to v3

### DIFF
--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -116,7 +116,6 @@ export class VehicleTestController implements IVehicleTestController {
       );
       return result;
     } catch (error) {
-      console.log('in insert:', error);
       if (
         error.statusCode === 400 &&
         error.body === enums.MESSAGES.CONDITIONAL_REQUEST_FAILED

--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -120,7 +120,10 @@ export class VehicleTestController implements IVehicleTestController {
       return result;
     } catch (error) {
       console.info('error: ', error);
-      if (error.statusCode === 400 && error.message === MESSAGES.CONDITIONAL_REQUEST_FAILED) {
+      if (
+        error.statusCode === 400 && 
+        error.message === MESSAGES.CONDITIONAL_REQUEST_FAILED
+      ) {
         console.info(
           'TestResultService.insertTestResult: Test Result id already exists',
           error,

--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -1,5 +1,3 @@
-import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
-import { ServiceException } from '@smithy/smithy-client';
 import { cloneDeep, differenceWith, isEqual, mergeWith } from 'lodash';
 import * as enums from '../assets/Enums';
 import * as models from '../models';
@@ -12,14 +10,13 @@ import { ExpiryDateStrategyFactory } from './expiry/ExpiryDateStrategyFactory';
 import { IExpiryDateStrategy } from './expiry/IExpiryDateStrategy';
 import { DateProvider } from './expiry/providers/DateProvider';
 import { TestDataProvider } from './expiry/providers/TestDataProvider';
-import { MESSAGES } from '../assets/Enums';
 
 @Service()
 export class VehicleTestController implements IVehicleTestController {
   constructor(
     public dataProvider: TestDataProvider,
     public dateProvider: DateProvider,
-  ) { }
+  ) {}
 
   // #region [rgba(52, 152, 219, 0.15)] Public functions
   /**
@@ -121,8 +118,8 @@ export class VehicleTestController implements IVehicleTestController {
     } catch (error) {
       console.info('error: ', error);
       if (
-        error.statusCode === 400 && 
-        error.message === MESSAGES.CONDITIONAL_REQUEST_FAILED
+        error.statusCode === 400 &&
+        error.message === enums.MESSAGES.CONDITIONAL_REQUEST_FAILED
       ) {
         console.info(
           'TestResultService.insertTestResult: Test Result id already exists',
@@ -204,7 +201,7 @@ export class VehicleTestController implements IVehicleTestController {
           testType,
           vehicleType:
             enums.VEHICLE_TYPE[
-            payload.vehicleType.toUpperCase() as keyof typeof enums.VEHICLE_TYPE
+              payload.vehicleType.toUpperCase() as keyof typeof enums.VEHICLE_TYPE
             ],
           recentExpiry,
           regnOrFirstUseDate:
@@ -456,7 +453,7 @@ export class VehicleTestController implements IVehicleTestController {
       (testType.testTypeClassification ===
         enums.TEST_TYPE_CLASSIFICATION.IVA_WITH_CERTIFICATE ||
         testType.testTypeClassification ===
-        enums.TEST_TYPE_CLASSIFICATION.MSVA_WITH_CERTIFICATE) &&
+          enums.TEST_TYPE_CLASSIFICATION.MSVA_WITH_CERTIFICATE) &&
       (!testType.certificateNumber || testType.certificateNumber === '')
     );
   }

--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -12,6 +12,7 @@ import { ExpiryDateStrategyFactory } from './expiry/ExpiryDateStrategyFactory';
 import { IExpiryDateStrategy } from './expiry/IExpiryDateStrategy';
 import { DateProvider } from './expiry/providers/DateProvider';
 import { TestDataProvider } from './expiry/providers/TestDataProvider';
+import { MESSAGES } from '../assets/Enums';
 
 @Service()
 export class VehicleTestController implements IVehicleTestController {
@@ -119,20 +120,13 @@ export class VehicleTestController implements IVehicleTestController {
       return result;
     } catch (error) {
       console.info('error: ', error);
-      if (error instanceof ConditionalCheckFailedException) {
+      if (error.statusCode === 400 && error.message === MESSAGES.CONDITIONAL_REQUEST_FAILED) {
         console.info(
           'TestResultService.insertTestResult: Test Result id already exists',
           error,
         );
         error = new models.HTTPResponse(201, enums.MESSAGES.ID_ALREADY_EXISTS);
       }
-      if ((error as ServiceException).$metadata?.httpStatusCode) {
-        error = new models.HTTPResponse(
-          (error as ServiceException).$metadata?.httpStatusCode ?? 500,
-          (error as ServiceException).message,
-        );
-      }
-
       throw error;
     }
   }

--- a/src/handlers/VehicleTestController.ts
+++ b/src/handlers/VehicleTestController.ts
@@ -116,10 +116,10 @@ export class VehicleTestController implements IVehicleTestController {
       );
       return result;
     } catch (error) {
-      console.info('error: ', error);
+      console.log('in insert:', error);
       if (
         error.statusCode === 400 &&
-        error.message === enums.MESSAGES.CONDITIONAL_REQUEST_FAILED
+        error.body === enums.MESSAGES.CONDITIONAL_REQUEST_FAILED
       ) {
         console.info(
           'TestResultService.insertTestResult: Test Result id already exists',

--- a/src/handlers/expiry/providers/TestDataProvider.ts
+++ b/src/handlers/expiry/providers/TestDataProvider.ts
@@ -242,12 +242,6 @@ export class TestDataProvider implements ITestDataProvider {
       return result.Attributes as models.ITestResult[];
     } catch (error) {
       console.error('TestDataProvider.insertTestResult -> ', error);
-      if (
-        error instanceof ConditionalCheckFailedException &&
-        error.$response?.statusCode
-      ) {
-        throw new models.HTTPError(error.$response?.statusCode, error.message);
-      }
       throw error;
     }
   }

--- a/src/handlers/expiry/providers/TestDataProvider.ts
+++ b/src/handlers/expiry/providers/TestDataProvider.ts
@@ -1,4 +1,4 @@
-import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+import { ServiceException } from '@smithy/smithy-client';
 import * as enums from '../../../assets/Enums';
 import * as models from '../../../models';
 import { Service } from '../../../models/injector/ServiceDecorator';
@@ -29,6 +29,9 @@ export class TestDataProvider implements ITestDataProvider {
         'TestDataProvider.getTestResultBySystemNumber: error-> ',
         error,
       );
+      if (error instanceof ServiceException) {
+        throw new models.HTTPError(error.$metadata.httpStatusCode ?? 500, error.message);
+      }
       throw error;
     }
   }
@@ -46,9 +49,11 @@ export class TestDataProvider implements ITestDataProvider {
       console.error(
         'TestDataProvider.getTestResultBySystemNumber: error-> ',
         error,
-      );
-      throw error;
-    }
+      );  if (error instanceof ServiceException) {
+        throw new models.HTTPError(error.$metadata.httpStatusCode ?? 500, error.message);
+      } 
+      throw error
+    };
   }
 
   public async getTestHistory(
@@ -73,6 +78,9 @@ export class TestDataProvider implements ITestDataProvider {
       );
     } catch (error) {
       console.log('TestDataProvider.getTestHistory: error -> ', error);
+      if (error instanceof ServiceException) {
+        throw new models.HTTPError(error.$metadata.httpStatusCode ?? 500, error.message);
+      }
       throw error;
     }
   }
@@ -252,8 +260,8 @@ export class TestDataProvider implements ITestDataProvider {
     } catch (error) {
       console.error('TestDataProvider.updateTestResult -> ', error);
       throw error;
-    }
   }
+}
 
   // #endregion
   // #region [rgba(0, 205, 30, 0.1)] Private Static functions

--- a/src/handlers/expiry/providers/TestDataProvider.ts
+++ b/src/handlers/expiry/providers/TestDataProvider.ts
@@ -1,6 +1,7 @@
-import { Service } from '../../../models/injector/ServiceDecorator';
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
 import * as enums from '../../../assets/Enums';
 import * as models from '../../../models';
+import { Service } from '../../../models/injector/ServiceDecorator';
 import * as utils from '../../../utils';
 import { DateProvider } from './DateProvider';
 import { ITestDataProvider } from './ITestDataProvider';
@@ -241,6 +242,12 @@ export class TestDataProvider implements ITestDataProvider {
       return result.Attributes as models.ITestResult[];
     } catch (error) {
       console.error('TestDataProvider.insertTestResult -> ', error);
+      if (
+        error instanceof ConditionalCheckFailedException &&
+        error.$response?.statusCode
+      ) {
+        throw new models.HTTPError(error.$response?.statusCode, error.message);
+      }
       throw error;
     }
   }

--- a/src/handlers/expiry/providers/TestDataProvider.ts
+++ b/src/handlers/expiry/providers/TestDataProvider.ts
@@ -30,7 +30,10 @@ export class TestDataProvider implements ITestDataProvider {
         error,
       );
       if (error instanceof ServiceException) {
-        throw new models.HTTPError(error.$metadata.httpStatusCode ?? 500, error.message);
+        throw new models.HTTPError(
+          error.$metadata.httpStatusCode ?? 500,
+          error.message,
+        );
       }
       throw error;
     }
@@ -49,11 +52,15 @@ export class TestDataProvider implements ITestDataProvider {
       console.error(
         'TestDataProvider.getTestResultBySystemNumber: error-> ',
         error,
-      );  if (error instanceof ServiceException) {
-        throw new models.HTTPError(error.$metadata.httpStatusCode ?? 500, error.message);
-      } 
-      throw error
-    };
+      );
+      if (error instanceof ServiceException) {
+        throw new models.HTTPError(
+          error.$metadata.httpStatusCode ?? 500,
+          error.message,
+        );
+      }
+      throw error;
+    }
   }
 
   public async getTestHistory(
@@ -79,7 +86,10 @@ export class TestDataProvider implements ITestDataProvider {
     } catch (error) {
       console.log('TestDataProvider.getTestHistory: error -> ', error);
       if (error instanceof ServiceException) {
-        throw new models.HTTPError(error.$metadata.httpStatusCode ?? 500, error.message);
+        throw new models.HTTPError(
+          error.$metadata.httpStatusCode ?? 500,
+          error.message,
+        );
       }
       throw error;
     }
@@ -260,8 +270,8 @@ export class TestDataProvider implements ITestDataProvider {
     } catch (error) {
       console.error('TestDataProvider.updateTestResult -> ', error);
       throw error;
+    }
   }
-}
 
   // #endregion
   // #region [rgba(0, 205, 30, 0.1)] Private Static functions

--- a/src/handlers/expiry/providers/TestDataProvider.ts
+++ b/src/handlers/expiry/providers/TestDataProvider.ts
@@ -242,7 +242,7 @@ export class TestDataProvider implements ITestDataProvider {
       return result.Attributes as models.ITestResult[];
     } catch (error) {
       console.error('TestDataProvider.insertTestResult -> ', error);
-      throw error;
+      throw new models.HTTPError(error.$metadata.httpStatusCode, error.message);
     }
   }
 

--- a/tests/unit/expiry/TestDataProvider.unitTest.ts
+++ b/tests/unit/expiry/TestDataProvider.unitTest.ts
@@ -343,7 +343,7 @@ describe('TestDataProvider', () => {
 
     it('should throw the error once it fails', async () => {
       testDataProvider = new TestDataProvider();
-      const error = { $metadata: {httpStatusCode: 400}, message: 'boom' };
+      const error = { $metadata: { httpStatusCode: 400 }, message: 'boom' };
       MockTestResultsDAO = jest.fn().mockImplementation(() => ({
         createSingle: (something: any) => Promise.reject(error),
       }));

--- a/tests/unit/expiry/TestDataProvider.unitTest.ts
+++ b/tests/unit/expiry/TestDataProvider.unitTest.ts
@@ -343,7 +343,7 @@ describe('TestDataProvider', () => {
 
     it('should throw the error once it fails', async () => {
       testDataProvider = new TestDataProvider();
-      const error = { statusCode: 400, body: 'boom' };
+      const error = { $metadata: {httpStatusCode: 400}, message: 'boom' };
       MockTestResultsDAO = jest.fn().mockImplementation(() => ({
         createSingle: (something: any) => Promise.reject(error),
       }));
@@ -354,7 +354,7 @@ describe('TestDataProvider', () => {
           {} as models.ITestResultPayload,
         );
       } catch (e) {
-        expect(e).toEqual(error);
+        expect(e.body).toEqual(error.message);
       }
     });
   });

--- a/tests/unit/expiry/TestDataProvider.unitTest.ts
+++ b/tests/unit/expiry/TestDataProvider.unitTest.ts
@@ -343,9 +343,9 @@ describe('TestDataProvider', () => {
 
     it('should throw the error once it fails', async () => {
       testDataProvider = new TestDataProvider();
-      const errorMsg = 'boom';
+      const error = { statusCode: 400, body: 'boom' };
       MockTestResultsDAO = jest.fn().mockImplementation(() => ({
-        createSingle: (something: any) => Promise.reject(errorMsg),
+        createSingle: (something: any) => Promise.reject(error),
       }));
 
       testDataProvider.testResultsDAO = new MockTestResultsDAO();
@@ -354,7 +354,7 @@ describe('TestDataProvider', () => {
           {} as models.ITestResultPayload,
         );
       } catch (e) {
-        expect(e).toBe(errorMsg);
+        expect(e).toEqual(error);
       }
     });
   });

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -268,7 +268,6 @@ describe('insertTestResult', () => {
       return testResultsService
         .insertTestResult(mockData)
         .catch((error: { statusCode: any; body: any }) => {
-          console.log('this error: ', error);
           expect(error).toBeInstanceOf(HTTPResponse);
           expect(error.statusCode).toBe(201);
           expect(error.body).toBe(`"${MESSAGES.ID_ALREADY_EXISTS}"`);

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -245,8 +245,8 @@ describe('insertTestResult', () => {
         getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
         createSingle: () =>
           Promise.reject({
-            statusCode: 400,
-            body: MESSAGES.CONDITIONAL_REQUEST_FAILED,
+            $metadata: {httpStatusCode: 400},
+            message: MESSAGES.CONDITIONAL_REQUEST_FAILED,
           }),
       }));
       testResultsService = new TestResultsService(new MockTestResultsDAO());

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -244,14 +244,13 @@ describe('insertTestResult', () => {
           }),
         getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
         createSingle: () =>
-          Promise.reject({
-            $metadata: {
-              httpStatusCode: 400,
-            },
-            message: MESSAGES.CONDITIONAL_REQUEST_FAILED,
-          } as ConditionalCheckFailedException),
+          Promise.reject(
+            {
+              statusCode: 400,
+              message: MESSAGES.CONDITIONAL_REQUEST_FAILED,
+            }
+          ),
       }));
-      client = mockClient
       testResultsService = new TestResultsService(new MockTestResultsDAO());
       mockData.testTypes.pop(); // removing the second test in the array as the mock implementation makes this record invalid
       for (const testType of mockData.testTypes) {
@@ -1935,7 +1934,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => {})
+            .then((insertedTestResult: any) => { })
             .catch((error: { statusCode: any; body: { errors: any[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -1986,7 +1985,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => {})
+            .then((insertedTestResult: any) => { })
             .catch((error: { statusCode: any; body: { errors: any[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -2128,7 +2127,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => {})
+            .then((insertedTestResult: any) => { })
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -2175,7 +2174,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => {})
+            .then((insertedTestResult: any) => { })
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -2225,7 +2224,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => {})
+            .then((insertedTestResult: any) => { })
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -2271,7 +2270,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => {})
+            .then((insertedTestResult: any) => { })
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -2320,7 +2319,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => {})
+            .then((insertedTestResult: any) => { })
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               console.log(error);
               expect(error).toBeInstanceOf(HTTPError);
@@ -2420,7 +2419,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => {})
+            .then((insertedTestResult: any) => { })
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -1,4 +1,3 @@
-import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
 import fs from 'fs';
 import { cloneDeep } from 'lodash';
 import path from 'path';
@@ -10,8 +9,9 @@ import {
   TEST_STATUS,
   VEHICLE_TYPES,
 } from '../../src/assets/Enums';
+import { HTTPResponse } from '../../src/models';
+import * as models from '../../src/models/HTTPError';
 import { HTTPError } from '../../src/models/HTTPError';
-import { HTTPResponse } from '../../src/models/HTTPResponse';
 import { ITestResultPayload } from '../../src/models/ITestResultPayload';
 import { TestResultsService } from '../../src/services/TestResultsService';
 import { ValidationUtil } from '../../src/utils/validationUtil';
@@ -246,7 +246,7 @@ describe('insertTestResult', () => {
         createSingle: () =>
           Promise.reject({
             statusCode: 400,
-            message: MESSAGES.CONDITIONAL_REQUEST_FAILED,
+            body: MESSAGES.CONDITIONAL_REQUEST_FAILED,
           }),
       }));
       testResultsService = new TestResultsService(new MockTestResultsDAO());
@@ -268,6 +268,7 @@ describe('insertTestResult', () => {
       return testResultsService
         .insertTestResult(mockData)
         .catch((error: { statusCode: any; body: any }) => {
+          console.log('this error: ', error);
           expect(error).toBeInstanceOf(HTTPResponse);
           expect(error.statusCode).toBe(201);
           expect(error.body).toBe(`"${MESSAGES.ID_ALREADY_EXISTS}"`);

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -244,12 +244,10 @@ describe('insertTestResult', () => {
           }),
         getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
         createSingle: () =>
-          Promise.reject(
-            {
-              statusCode: 400,
-              message: MESSAGES.CONDITIONAL_REQUEST_FAILED,
-            }
-          ),
+          Promise.reject({
+            statusCode: 400,
+            message: MESSAGES.CONDITIONAL_REQUEST_FAILED,
+          }),
       }));
       testResultsService = new TestResultsService(new MockTestResultsDAO());
       mockData.testTypes.pop(); // removing the second test in the array as the mock implementation makes this record invalid
@@ -1934,7 +1932,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => { })
+            .then((insertedTestResult: any) => {})
             .catch((error: { statusCode: any; body: { errors: any[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -1985,7 +1983,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => { })
+            .then((insertedTestResult: any) => {})
             .catch((error: { statusCode: any; body: { errors: any[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -2127,7 +2125,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => { })
+            .then((insertedTestResult: any) => {})
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -2174,7 +2172,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => { })
+            .then((insertedTestResult: any) => {})
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -2224,7 +2222,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => { })
+            .then((insertedTestResult: any) => {})
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -2270,7 +2268,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => { })
+            .then((insertedTestResult: any) => {})
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);
@@ -2319,7 +2317,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => { })
+            .then((insertedTestResult: any) => {})
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               console.log(error);
               expect(error).toBeInstanceOf(HTTPError);
@@ -2419,7 +2417,7 @@ describe('insertTestResult', () => {
           testResultsService
             .insertTestResult(clonedTestResult)
             // tslint:disable-next-line: no-empty
-            .then((insertedTestResult: any) => { })
+            .then((insertedTestResult: any) => {})
             .catch((error: { statusCode: any; body: { errors: string[] } }) => {
               expect(error).toBeInstanceOf(HTTPError);
               expect(error.statusCode).toBe(400);

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -245,7 +245,7 @@ describe('insertTestResult', () => {
         getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
         createSingle: () =>
           Promise.reject({
-            $metadata: {httpStatusCode: 400},
+            $metadata: { httpStatusCode: 400 },
             message: MESSAGES.CONDITIONAL_REQUEST_FAILED,
           }),
       }));

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -1,18 +1,18 @@
 import fs from 'fs';
-import path from 'path';
 import { cloneDeep } from 'lodash';
-import { TestResultsService } from '../../src/services/TestResultsService';
-import { HTTPError } from '../../src/models/HTTPError';
+import path from 'path';
 import {
-  MESSAGES,
   ERRORS,
-  VEHICLE_TYPES,
-  TEST_STATUS,
-  TEST_RESULT,
+  MESSAGES,
   TESTING_ERRORS,
+  TEST_RESULT,
+  TEST_STATUS,
+  VEHICLE_TYPES,
 } from '../../src/assets/Enums';
-import { ITestResultPayload } from '../../src/models/ITestResultPayload';
+import { HTTPError } from '../../src/models/HTTPError';
 import { HTTPResponse } from '../../src/models/HTTPResponse';
+import { ITestResultPayload } from '../../src/models/ITestResultPayload';
+import { TestResultsService } from '../../src/services/TestResultsService';
 import { ValidationUtil } from '../../src/utils/validationUtil';
 
 describe('insertTestResult', () => {
@@ -244,8 +244,10 @@ describe('insertTestResult', () => {
         getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
         createSingle: () =>
           Promise.reject({
-            statusCode: 400,
-            message: MESSAGES.CONDITIONAL_REQUEST_FAILED,
+            $response: {
+              statusCode: 400,
+              body: MESSAGES.CONDITIONAL_REQUEST_FAILED,
+            },
           }),
       }));
       testResultsService = new TestResultsService(new MockTestResultsDAO());

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -1,3 +1,4 @@
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
 import fs from 'fs';
 import { cloneDeep } from 'lodash';
 import path from 'path';
@@ -244,12 +245,13 @@ describe('insertTestResult', () => {
         getBySystemNumber: (systemNumber: any) => Promise.resolve([]),
         createSingle: () =>
           Promise.reject({
-            $response: {
-              statusCode: 400,
-              body: MESSAGES.CONDITIONAL_REQUEST_FAILED,
+            $metadata: {
+              httpStatusCode: 400,
             },
-          }),
+            message: MESSAGES.CONDITIONAL_REQUEST_FAILED,
+          } as ConditionalCheckFailedException),
       }));
+      client = mockClient
       testResultsService = new TestResultsService(new MockTestResultsDAO());
       mockData.testTypes.pop(); // removing the second test in the array as the mock implementation makes this record invalid
       for (const testType of mockData.testTypes) {

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -10,7 +10,6 @@ import {
   VEHICLE_TYPES,
 } from '../../src/assets/Enums';
 import { HTTPResponse } from '../../src/models';
-import * as models from '../../src/models/HTTPError';
 import { HTTPError } from '../../src/models/HTTPError';
 import { ITestResultPayload } from '../../src/models/ITestResultPayload';
 import { TestResultsService } from '../../src/services/TestResultsService';


### PR DESCRIPTION
## Upgrade cvs-svc-test-results from AWS SDK v2 to v3

One line description

resolves issue with sending 400 and incorrect error message for creating a duplicate testId

reformats the errors for get database methods so they'll return usefully and with correct error codes. 

Ignores put method errors as they all default to 500 code with the message which remains the same in aws-sdk v3

[[link to ticket number]()](https://dvsa.atlassian.net/browse/CB2-11271)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
