### PR TITLE
feat(cb2-13369): Amend centralDocs object validation to be optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-lambda": "^3.552.0",
         "@aws-sdk/lib-dynamodb": "^3.552.0",
         "@aws-sdk/smithy-client": "^3.374.0",
-        "@dvsa/cvs-microservice-common": "1.2.0",
+        "@dvsa/cvs-microservice-common": "1.2.1",
         "@dvsa/cvs-type-definitions": "6.0.0",
         "@smithy/smithy-client": "^2.5.1",
         "@smithy/util-utf8": "^2.3.0",
@@ -3515,9 +3515,9 @@
       }
     },
     "node_modules/@dvsa/cvs-microservice-common": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-microservice-common/-/cvs-microservice-common-1.2.0.tgz",
-      "integrity": "sha512-OqY5LkH9Is0Gv8DGkWfHiTHUnXCprF+d3VyjPZxjsnrKihPcJpzdo9B7eybYL3rxSG4STnw8iJb0dIqfNqqShQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-microservice-common/-/cvs-microservice-common-1.2.1.tgz",
+      "integrity": "sha512-/1uAhshsNKik/PLQ6VrDqnh1x2jOWAlnFP90o2a/CdVgv74YtWwUqYutFiclUkTpE0sefasVAhpqOIyRob6yDg==",
       "dependencies": {
         "class-transformer": "^0.5.1",
         "dayjs": "^1.11.11"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "joi": "^17.12.1",
     "js-yaml": "^3.14.1",
     "lodash": "^4.17.21",
-    "@dvsa/cvs-microservice-common": "1.2.0",
+    "@dvsa/cvs-microservice-common": "1.2.1",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.40",
     "node-yaml": "^4.0.1",

--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -64,7 +64,6 @@ export enum MESSAGES {
   CONDITIONAL_REQUEST_FAILED = 'The conditional request failed',
   REASON_FOR_ABANDONING_NOT_PRESENT = 'Reason for Abandoning not present on all abandoned tests',
   CENTRAL_DOCS_NOT_AVAILABLE_FOR_TEST_TYPE = 'Central documents can not be issued for test type',
-  CENTRAL_DOCS_NOT_AVAILABLE_FOR_FAIL_STATUS = 'Central documents can not be issued for a test status of fail',
 }
 
 export enum VEHICLE_TYPE {

--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -63,6 +63,8 @@ export enum MESSAGES {
   ID_ALREADY_EXISTS = 'Test Result id already exists',
   CONDITIONAL_REQUEST_FAILED = 'The conditional request failed',
   REASON_FOR_ABANDONING_NOT_PRESENT = 'Reason for Abandoning not present on all abandoned tests',
+  CENTRAL_DOCS_NOT_AVAILABLE_FOR_TEST_TYPE = 'Central documents can not be issued for test type',
+  CENTRAL_DOCS_NOT_AVAILABLE_FOR_FAIL_STATUS = 'Central documents can not be issued for a test status of fail',
 }
 
 export enum VEHICLE_TYPE {

--- a/src/utils/validationUtil.ts
+++ b/src/utils/validationUtil.ts
@@ -51,9 +51,7 @@ export class ValidationUtil {
     //   this.ivaFailedHasRequiredFields(payload.testTypes);
     // }
 
-    if (payload.testStatus === enums.TEST_STATUS.SUBMITTED) {
-      this.validateCentralDocs(payload.testTypes);
-    }
+    this.validateCentralDocs(payload.testTypes);
 
     const validation: ValidationResult<any> | any | null = validationSchema
       ? validationSchema.validate(payload)

--- a/src/utils/validationUtil.ts
+++ b/src/utils/validationUtil.ts
@@ -584,27 +584,35 @@ export class ValidationUtil {
   public static validateCentralDocs(testTypes: TestType[]): void {
     testTypes.forEach((testType) => {
       // if centralDocs is not present, then no object to validate immediately return true
-      if (!testType.centralDocs) { return true; }
+      if (!testType.centralDocs) {
+        return true;
+      }
 
       // if centralDocs is present, does the test type id exist in the list of central docs test types
       const validTestTypeId = TestTypeHelper.validateTestTypeIdInList(
-          CENTRAL_DOCS_TEST,
-          testType.testTypeId,
+        CENTRAL_DOCS_TEST,
+        testType.testTypeId,
       );
 
       // if the test type is not in the list of central docs test types, throw an error
       if (!validTestTypeId) {
         throw new models.HTTPError(
-            400,
-            `${enums.MESSAGES.CENTRAL_DOCS_NOT_AVAILABLE_FOR_TEST_TYPE} ${testType.testTypeId}`,
+          400,
+          `${enums.MESSAGES.CENTRAL_DOCS_NOT_AVAILABLE_FOR_TEST_TYPE} ${testType.testTypeId}`,
         );
       }
 
       // if it is in the list of central docs test types, is it a valid testResult of pass or prs
-      if (validTestTypeId && !(testType.testResult === enums.TEST_RESULT.PASS || testType.testResult === enums.TEST_RESULT.PRS)) {
+      if (
+        validTestTypeId &&
+        !(
+          testType.testResult === enums.TEST_RESULT.PASS ||
+          testType.testResult === enums.TEST_RESULT.PRS
+        )
+      ) {
         throw new models.HTTPError(
-            400,
-            enums.MESSAGES.CENTRAL_DOCS_NOT_AVAILABLE_FOR_FAIL_STATUS,
+          400,
+          enums.MESSAGES.CENTRAL_DOCS_NOT_AVAILABLE_FOR_FAIL_STATUS,
         );
       }
     });

--- a/src/utils/validationUtil.ts
+++ b/src/utils/validationUtil.ts
@@ -601,20 +601,6 @@ export class ValidationUtil {
           `${enums.MESSAGES.CENTRAL_DOCS_NOT_AVAILABLE_FOR_TEST_TYPE} ${testType.testTypeId}`,
         );
       }
-
-      // if it is in the list of central docs test types, is it a valid testResult of pass or prs
-      if (
-        validTestTypeId &&
-        !(
-          testType.testResult === enums.TEST_RESULT.PASS ||
-          testType.testResult === enums.TEST_RESULT.PRS
-        )
-      ) {
-        throw new models.HTTPError(
-          400,
-          enums.MESSAGES.CENTRAL_DOCS_NOT_AVAILABLE_FOR_FAIL_STATUS,
-        );
-      }
     });
   }
 }

--- a/tests/integration/postTestResults.intTest.ts
+++ b/tests/integration/postTestResults.intTest.ts
@@ -7,18 +7,18 @@ const url = 'http://localhost:3006/';
 const request = supertest(url);
 
 describe('postTestResults', () => {
-  context('when submitting a test result with central docs', () => {
-    it('should return 400 when central docs are required but missing', async () => {
+  context('when submitting a fail test result with central docs on a valid test type id', () => {
+    it('should return 400', async () => {
       const testResult =
         testResultsPostMock[15] as unknown as ITestResultPayload;
 
       testResult.testTypes[0].testTypeId = CENTRAL_DOCS_TEST.IDS[3];
-      delete testResult.testTypes[0].centralDocs;
+      testResult.testTypes[0].testResult = 'fail';
 
       const res = await request.post('test-results').send(testResult);
 
       expect(res.status).toBe(400);
-      expect(res.body).toBe('Central docs required for test type 47');
+      expect(res.body).toBe('Central documents can not be issued for a test status of fail');
     });
   });
 

--- a/tests/integration/postTestResults.intTest.ts
+++ b/tests/integration/postTestResults.intTest.ts
@@ -7,20 +7,25 @@ const url = 'http://localhost:3006/';
 const request = supertest(url);
 
 describe('postTestResults', () => {
-  context('when submitting a fail test result with central docs on a valid test type id', () => {
-    it('should return 400', async () => {
-      const testResult =
-        testResultsPostMock[15] as unknown as ITestResultPayload;
+  context(
+    'when submitting a fail test result with central docs on a valid test type id',
+    () => {
+      it('should return 400', async () => {
+        const testResult =
+          testResultsPostMock[15] as unknown as ITestResultPayload;
 
-      testResult.testTypes[0].testTypeId = CENTRAL_DOCS_TEST.IDS[3];
-      testResult.testTypes[0].testResult = 'fail';
+        testResult.testTypes[0].testTypeId = CENTRAL_DOCS_TEST.IDS[3];
+        testResult.testTypes[0].testResult = 'fail';
 
-      const res = await request.post('test-results').send(testResult);
+        const res = await request.post('test-results').send(testResult);
 
-      expect(res.status).toBe(400);
-      expect(res.body).toBe('Central documents can not be issued for a test status of fail');
-    });
-  });
+        expect(res.status).toBe(400);
+        expect(res.body).toBe(
+          'Central documents can not be issued for a test status of fail',
+        );
+      });
+    },
+  );
 
   context('when submitting an invalid test result', () => {
     it('should return 400 for missing required fields', async () => {

--- a/tests/integration/postTestResults.intTest.ts
+++ b/tests/integration/postTestResults.intTest.ts
@@ -1,5 +1,4 @@
 import supertest from 'supertest';
-import { CENTRAL_DOCS_TEST } from '@dvsa/cvs-microservice-common/classes/testTypes/Constants';
 import { ITestResultPayload } from '../../src/models';
 import testResultsPostMock from '../resources/test-results-post.json';
 
@@ -7,26 +6,6 @@ const url = 'http://localhost:3006/';
 const request = supertest(url);
 
 describe('postTestResults', () => {
-  context(
-    'when submitting a fail test result with central docs on a valid test type id',
-    () => {
-      it('should return 400', async () => {
-        const testResult =
-          testResultsPostMock[15] as unknown as ITestResultPayload;
-
-        testResult.testTypes[0].testTypeId = CENTRAL_DOCS_TEST.IDS[3];
-        testResult.testTypes[0].testResult = 'fail';
-
-        const res = await request.post('test-results').send(testResult);
-
-        expect(res.status).toBe(400);
-        expect(res.body).toBe(
-          'Central documents can not be issued for a test status of fail',
-        );
-      });
-    },
-  );
-
   context('when submitting an invalid test result', () => {
     it('should return 400 for missing required fields', async () => {
       const testResult =

--- a/tests/resources/test-results-post.json
+++ b/tests/resources/test-results-post.json
@@ -525,11 +525,6 @@
         "certificateNumber": "12512ds",
         "testTypeName": "Annual test",
         "additionalNotesRecorded": "VEHICLE FRONT REGISTRATION PLATE MISSING",
-        "centralDocs": {
-          "issueRequired": false,
-          "notes": "notes",
-          "reasonsForIssue": ["issue reason"]
-        },
         "customDefects": [
           {
             "referenceNumber": "abcd",
@@ -720,11 +715,6 @@
           "code": "m",
           "description": "modification or change of engine"
         },
-        "centralDocs": {
-          "issueRequired": false,
-          "notes": "notes",
-          "reasonsForIssue": ["issue reason"]
-        },
         "emissionStandard": "0.03 g/kWh Euro IV PM",
         "fuelType": "gas-cng",
         "smokeTestKLimitApplied": "123",
@@ -818,11 +808,6 @@
         "reasonForAbandoning": null,
         "additionalCommentsForAbandon": null,
         "additionalNotesRecorded": "Test notes",
-        "centralDocs": {
-          "issueRequired": false,
-          "notes": "notes",
-          "reasonsForIssue": ["issue reason"]
-        },
         "customDefects": [
           {
             "referenceNumber": "abcd",
@@ -896,11 +881,6 @@
             "defectNotes": null
           }
         ],
-        "centralDocs": {
-          "issueRequired": false,
-          "notes": "notes",
-          "reasonsForIssue": ["issue reason"]
-        },
         "defects": []
       }
     ]
@@ -967,11 +947,6 @@
             "defectNotes": null
           }
         ],
-        "centralDocs": {
-          "issueRequired": false,
-          "notes": "notes",
-          "reasonsForIssue": ["issue reason"]
-        },
         "defects": []
       }
     ]
@@ -1037,11 +1012,6 @@
             "defectNotes": null
           }
         ],
-        "centralDocs": {
-          "issueRequired": false,
-          "notes": "notes",
-          "reasonsForIssue": ["issue reason"]
-        },
         "defects": []
       }
     ],
@@ -1186,42 +1156,62 @@
     "bodyType": { "code": "test code", "description": "test description" }
   },
   {
-    "vin": "YV3S2G5265A101407",
-    "vrm": "PO54ACV",
-    "countryOfRegistration": "gbz",
-    "euVehicleCategory": "m2",
-    "odometerReading": 4000,
-    "odometerReadingUnits": "kilometres",
-    "preparerName": "",
-    "preparerId": "",
-    "make": "DARWIN/EAST LANCS",
-    "model": "VYKING MYLLENIUM",
-    "bodyType": {
-      "code": "d",
-      "description": "double decker"
-    },
-    "contingencyTestNumber": "1534432",
-    "testStartTimestamp": "2024-07-18T10:00:00.000",
-    "testEndTimestamp": "2024-07-18T12:00:00.000",
+    "testerStaffId": "1",
+    "systemNumber": "1218",
+    "testResultId": "195",
+    "testStartTimestamp": "2019-01-14T10:36:33.987Z",
+    "testEndTimestamp": "2019-01-14T10:36:33.987Z",
+    "testStatus": "submitted",
+    "numberOfWheelsDriven": 3,
     "testTypes": [
       {
+        "prohibitionIssued": false,
+        "additionalCommentsForAbandon": "none",
+        "testTypeEndTimestamp": "2019-01-14T10:36:33.987Z",
+        "secondaryCertificateNumber": "1234",
+        "reasonForAbandoning": "none",
+        "testTypeId": "95",
+        "testTypeStartTimestamp": "2019-01-14T10:36:33.987Z",
+        "certificateNumber": "W01A00209",
+        "testTypeName": "First test",
+        "additionalNotesRecorded": "VEHICLE FRONT REGISTRATION PLATE MISSING",
+        "customDefects": [
+          {
+            "referenceNumber": "abcd",
+            "defectName": "Some custom defect",
+            "defectNotes": "some defect noe"
+          }
+        ],
+        "defects": [
+          {
+            "prohibitionIssued": false,
+            "deficiencyCategory": "major",
+            "deficiencyText": "missing.",
+            "prs": false,
+            "additionalInformation": {
+              "location": {
+                "axleNumber": null,
+                "horizontal": null,
+                "vertical": null,
+                "longitudinal": "front",
+                "rowNumber": null,
+                "lateral": null,
+                "seatNumber": null
+              },
+              "notes": "None"
+            },
+            "itemNumber": 1,
+            "deficiencyRef": "1.1.a",
+            "stdForProhibition": false,
+            "deficiencySubId": null,
+            "imDescription": "Registration Plate",
+            "deficiencyId": "a",
+            "itemDescription": "A registration plate:",
+            "imNumber": 1
+          }
+        ],
+        "name": "First test",
         "testResult": "pass",
-        "testTypeName": "COIF with annual test",
-        "reasonForAbandoning": null,
-        "additionalCommentsForAbandon": null,
-        "certificateNumber": "",
-        "secondaryCertificateNumber": "34523453452345",
-        "testTypeStartTimestamp": "2024-07-18T10:00:00.000",
-        "testTypeEndTimestamp": "2024-07-18T12:00:00.000",
-        "prohibitionIssued": false,
-        "seatbeltInstallationCheckDate": true,
-        "numberOfSeatbeltsFitted": 4,
-        "lastSeatbeltInstallationCheckDate": "2024-07-18T00:00:00.000",
-        "additionalNotesRecorded": "",
-        "defects": [],
-        "testTypeId": "142",
-        "name": "With annual test",
-        "customDefects": [],
         "centralDocs": {
           "issueRequired": false,
           "notes": "notes",
@@ -1229,110 +1219,25 @@
         }
       }
     ],
-    "testStationName": "Swansea Test HQ",
-    "testStationPNumber": "14-7160003",
-    "testStationType": "hq",
-    "testerStaffId": "8bd2avcf-c31e-4669-acb7-54bc3878e1b0",
-    "testerName": "CVS Dev",
-    "testerEmailAddress": "CVS.Dev@dvsagov.onmicrosoft.com",
-    "reasonForCreation": "TEST DATA",
-    "testResultId": "4ea8a6a9-b670-4960-9dfc-6a2242791c68",
-    "vehicleType": "psv",
-    "testStatus": "submitted",
-    "reasonForCancellation": "",
-    "systemNumber": "3128310",
     "vehicleClass": {
-      "code": "l",
-      "description": "large psv(ie: greater than 23 seats)"
+      "description": "motorbikes over 200cc or with a sidecar",
+      "code": "2"
     },
+    "vin": "P012301230123",
+    "testStationName": "Rowe, Wunsch and Wisoky",
     "noOfAxles": 2,
-    "numberOfWheelsDriven": 2,
-    "regnDate": "2004-08-23",
-    "firstUseDate": null,
-    "createdByName": "Dobbie1",
-    "createdById": "3341037-bb122-4c54-9gfa-a2413asdfdsaf45",
-    "lastUpdatedAt": "2024-07-18T14:03:23.155Z",
-    "lastUpdatedByName": "SA_Daniel Searle1",
-    "lastUpdatedById": "3341037-bb122-4c54-9gfa-a2413asdfdsaf45",
-    "numberOfSeats": 70,
+    "vehicleType": "trl",
+    "countryOfRegistration": "united kingdom",
+    "preparerId": "ak4434",
+    "preparerName": "Durrell Vehicles Limited",
     "vehicleConfiguration": "rigid",
-    "typeOfTest": "contingency",
-    "source": "vtm",
-    "vehicleSize": "large"
-  },
-  {
-    "vin": "YV3S2G5265A101407",
-    "vrm": "PO54ACV",
-    "countryOfRegistration": "gbz",
-    "euVehicleCategory": "m2",
-    "odometerReading": 4000,
-    "odometerReadingUnits": "kilometres",
-    "preparerName": "",
-    "preparerId": "",
-    "make": "DARWIN/EAST LANCS",
-    "model": "VYKING MYLLENIUM",
-    "bodyType": {
-      "code": "d",
-      "description": "double decker"
-    },
-    "contingencyTestNumber": "1534432",
-    "testStartTimestamp": "2024-07-18T10:00:00.000",
-    "testEndTimestamp": "2024-07-18T12:00:00.000",
-    "testTypes": [
-      {
-        "testResult": "fail",
-        "testTypeName": "COIF with annual test",
-        "reasonForAbandoning": null,
-        "additionalCommentsForAbandon": null,
-        "certificateNumber": "",
-        "secondaryCertificateNumber": "34523453452345",
-        "testTypeStartTimestamp": "2024-07-18T10:00:00.000",
-        "testTypeEndTimestamp": "2024-07-18T12:00:00.000",
-        "prohibitionIssued": false,
-        "seatbeltInstallationCheckDate": true,
-        "numberOfSeatbeltsFitted": 4,
-        "lastSeatbeltInstallationCheckDate": "2024-07-18T00:00:00.000",
-        "additionalNotesRecorded": "",
-        "defects": [],
-        "testTypeId": "142",
-        "name": "With annual test",
-        "customDefects": [],
-        "centralDocs": {
-          "issueRequired": false,
-          "notes": "notes",
-          "reasonsForIssue": ["issue reason"]
-        }
-      }
-    ],
-    "testStationName": "Swansea Test HQ",
-    "testStationPNumber": "14-7160003",
-    "testStationType": "hq",
-    "testerStaffId": "8bd2avcf-c31e-4669-acb7-54bc3878e1b0",
-    "testerName": "CVS Dev",
-    "testerEmailAddress": "CVS.Dev@dvsagov.onmicrosoft.com",
-    "reasonForCreation": "TEST DATA",
-    "testResultId": "4ea8a6a9-b670-4960-9dfc-6a2242791c68",
-    "vehicleType": "psv",
-    "testStatus": "submitted",
-    "reasonForCancellation": "",
-    "systemNumber": "3128310",
-    "vehicleClass": {
-      "code": "l",
-      "description": "large psv(ie: greater than 23 seats)"
-    },
-    "noOfAxles": 2,
-    "numberOfWheelsDriven": 2,
-    "regnDate": "2004-08-23",
-    "firstUseDate": null,
-    "createdByName": "Dobbie1",
-    "createdById": "3341037-bb122-4c54-9gfa-a2413asdfdsaf45",
-    "lastUpdatedAt": "2024-07-18T14:03:23.155Z",
-    "lastUpdatedByName": "SA_Daniel Searle1",
-    "lastUpdatedById": "3341037-bb122-4c54-9gfa-a2413asdfdsaf45",
-    "numberOfSeats": 70,
-    "vehicleConfiguration": "rigid",
-    "typeOfTest": "contingency",
-    "source": "vtm",
-    "vehicleSize": "large"
+    "testStationType": "gvts",
+    "reasonForCancellation": "none",
+    "testerName": "Dorel",
+    "testStationPNumber": "87-1369569",
+    "testerEmailAddress": "dorel.popescu@dvsagov.uk",
+    "euVehicleCategory": "o1",
+    "trailerId": "abcd",
+    "firstUseDate": "2018-11-11"
   }
 ]

--- a/tests/resources/test-results-post.json
+++ b/tests/resources/test-results-post.json
@@ -1085,12 +1085,7 @@
           }
         ],
         "defects": [],
-        "requiredStandards": [],
-        "centralDocs": {
-          "issueRequired": false,
-          "notes": "notes",
-          "reasonsForIssue": ["issue reason"]
-        }
+        "requiredStandards": []
       }
     ],
     "testStationName": "Abshire-Kub",
@@ -1211,6 +1206,81 @@
     "testTypes": [
       {
         "testResult": "pass",
+        "testTypeName": "COIF with annual test",
+        "reasonForAbandoning": null,
+        "additionalCommentsForAbandon": null,
+        "certificateNumber": "",
+        "secondaryCertificateNumber": "34523453452345",
+        "testTypeStartTimestamp": "2024-07-18T10:00:00.000",
+        "testTypeEndTimestamp": "2024-07-18T12:00:00.000",
+        "prohibitionIssued": false,
+        "seatbeltInstallationCheckDate": true,
+        "numberOfSeatbeltsFitted": 4,
+        "lastSeatbeltInstallationCheckDate": "2024-07-18T00:00:00.000",
+        "additionalNotesRecorded": "",
+        "defects": [],
+        "testTypeId": "142",
+        "name": "With annual test",
+        "customDefects": [],
+        "centralDocs": {
+          "issueRequired": false,
+          "notes": "notes",
+          "reasonsForIssue": ["issue reason"]
+        }
+      }
+    ],
+    "testStationName": "Swansea Test HQ",
+    "testStationPNumber": "14-7160003",
+    "testStationType": "hq",
+    "testerStaffId": "8bd2avcf-c31e-4669-acb7-54bc3878e1b0",
+    "testerName": "CVS Dev",
+    "testerEmailAddress": "CVS.Dev@dvsagov.onmicrosoft.com",
+    "reasonForCreation": "TEST DATA",
+    "testResultId": "4ea8a6a9-b670-4960-9dfc-6a2242791c68",
+    "vehicleType": "psv",
+    "testStatus": "submitted",
+    "reasonForCancellation": "",
+    "systemNumber": "3128310",
+    "vehicleClass": {
+      "code": "l",
+      "description": "large psv(ie: greater than 23 seats)"
+    },
+    "noOfAxles": 2,
+    "numberOfWheelsDriven": 2,
+    "regnDate": "2004-08-23",
+    "firstUseDate": null,
+    "createdByName": "Dobbie1",
+    "createdById": "3341037-bb122-4c54-9gfa-a2413asdfdsaf45",
+    "lastUpdatedAt": "2024-07-18T14:03:23.155Z",
+    "lastUpdatedByName": "SA_Daniel Searle1",
+    "lastUpdatedById": "3341037-bb122-4c54-9gfa-a2413asdfdsaf45",
+    "numberOfSeats": 70,
+    "vehicleConfiguration": "rigid",
+    "typeOfTest": "contingency",
+    "source": "vtm",
+    "vehicleSize": "large"
+  },
+  {
+    "vin": "YV3S2G5265A101407",
+    "vrm": "PO54ACV",
+    "countryOfRegistration": "gbz",
+    "euVehicleCategory": "m2",
+    "odometerReading": 4000,
+    "odometerReadingUnits": "kilometres",
+    "preparerName": "",
+    "preparerId": "",
+    "make": "DARWIN/EAST LANCS",
+    "model": "VYKING MYLLENIUM",
+    "bodyType": {
+      "code": "d",
+      "description": "double decker"
+    },
+    "contingencyTestNumber": "1534432",
+    "testStartTimestamp": "2024-07-18T10:00:00.000",
+    "testEndTimestamp": "2024-07-18T12:00:00.000",
+    "testTypes": [
+      {
+        "testResult": "fail",
         "testTypeName": "COIF with annual test",
         "reasonForAbandoning": null,
         "additionalCommentsForAbandon": null,

--- a/tests/resources/test-results.json
+++ b/tests/resources/test-results.json
@@ -1939,12 +1939,7 @@
         "testTypeEndTimestamp": "2023-01-14T10:36:33.987Z",
         "testTypeId": "95",
         "testTypeName": "First test",
-        "testTypeStartTimestamp": "2023-01-14T10:36:33.987Z",
-        "centralDocs": {
-          "issueRequired": false,
-          "notes": "notes",
-          "reasonsForIssue": ["issue reason"]
-        }
+        "testTypeStartTimestamp": "2023-01-14T10:36:33.987Z"
       }
     ],
     "trailerId": "C234567",

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3377,7 +3377,7 @@ describe('insertTestResult', () => {
       });
 
       it('should throw for mixed valid and invalid types', () => {
-        const testResultFail = { ...testResultsPostMock[16] } as ITestResultPayload;
+        const testResultFail = { ...testResultsPostMock[15] } as ITestResultPayload;
         testResultFail.testTypes[0].centralDocs = { issueRequired: true, reasonsForIssue: [] }
         const testTypes = [
           createTestType(CENTRAL_DOCS_TEST.IDS[0], { issueRequired: true }),
@@ -3401,8 +3401,9 @@ describe('insertTestResult', () => {
         }
       });
 
-      it('should throw for valid type but invalid test status', () => {
-          const testResultFail = { ...testResultsPostMock[16] } as ITestResultPayload;
+      it('should throw for valid type but invalid test result', () => {
+          const testResultFail = { ...testResultsPostMock[15] } as ITestResultPayload;
+          testResultFail.testTypes[0].testResult = 'fail';
           testResultFail.testTypes[0].centralDocs = { issueRequired: true, reasonsForIssue: [] }
           const testTypes = [
               testResultFail.testTypes[0],

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -2399,7 +2399,6 @@ describe('insertTestResult', () => {
       it('should throw error', () => {
         const testResult = testResultsPostMock[8];
         const clonedTestResult = cloneDeep(testResult);
-        delete clonedTestResult.testTypes[0].centralDocs;
         clonedTestResult.testTypes[0].certificateNumber = null;
         clonedTestResult.testTypes[0].testResult = 'fail';
         MockTestResultsDAO = jest.fn().mockImplementation(() => ({
@@ -3261,12 +3260,12 @@ describe('insertTestResult', () => {
           ).toThrow(HTTPError);
 
           try {
-              ValidationUtil.validateInsertTestResultPayload(testResult);
+            ValidationUtil.validateInsertTestResultPayload(testResult);
           } catch (err) {
             const error = err as HTTPError;
             expect(error.statusCode).toBe(400);
             expect(error.body.errors[0]).toBe(
-                '"testTypes[0].centralDocs.reasonsForIssue" is required',
+              '"testTypes[0].centralDocs.reasonsForIssue" is required',
             );
           }
         });
@@ -3354,7 +3353,7 @@ describe('insertTestResult', () => {
 
       it('should throw for invalid test type with central docs', () => {
         const testTypes = [
-          createTestType('1',  {
+          createTestType('1', {
             issueRequired: true,
             notes: 'notes',
             reasonsForIssue: ['reason'],
@@ -3371,21 +3370,26 @@ describe('insertTestResult', () => {
           expect(error).toBeInstanceOf(HTTPError);
           expect(error.statusCode).toBe(400);
           expect(error.body).toBe(
-            "Central documents can not be issued for test type 1",
+            'Central documents can not be issued for test type 1',
           );
         }
       });
 
       it('should throw for mixed valid and invalid types', () => {
-        const testResultFail = { ...testResultsPostMock[15] } as ITestResultPayload;
-        testResultFail.testTypes[0].centralDocs = { issueRequired: true, reasonsForIssue: [] }
+        const testResultFail = {
+          ...testResultsPostMock[15],
+        } as ITestResultPayload;
+        testResultFail.testTypes[0].centralDocs = {
+          issueRequired: true,
+          reasonsForIssue: [],
+        };
         const testTypes = [
           createTestType(CENTRAL_DOCS_TEST.IDS[0], { issueRequired: true }),
-           createTestType('1',  {
-               issueRequired: true,
-               notes: 'notes',
-               reasonsForIssue: ['reason'],
-           }),
+          createTestType('1', {
+            issueRequired: true,
+            notes: 'notes',
+            reasonsForIssue: ['reason'],
+          }),
         ];
         expect(() => ValidationUtil.validateCentralDocs(testTypes)).toThrow(
           HTTPError,
@@ -3402,25 +3406,28 @@ describe('insertTestResult', () => {
       });
 
       it('should throw for valid type but invalid test result', () => {
-          const testResultFail = { ...testResultsPostMock[15] } as ITestResultPayload;
-          testResultFail.testTypes[0].testResult = 'fail';
-          testResultFail.testTypes[0].centralDocs = { issueRequired: true, reasonsForIssue: [] }
-          const testTypes = [
-              testResultFail.testTypes[0],
-          ];
-          expect(() => ValidationUtil.validateCentralDocs(testTypes)).toThrow(
-              HTTPError,
+        const testResultFail = {
+          ...testResultsPostMock[15],
+        } as ITestResultPayload;
+        testResultFail.testTypes[0].testResult = 'fail';
+        testResultFail.testTypes[0].centralDocs = {
+          issueRequired: true,
+          reasonsForIssue: [],
+        };
+        const testTypes = [testResultFail.testTypes[0]];
+        expect(() => ValidationUtil.validateCentralDocs(testTypes)).toThrow(
+          HTTPError,
+        );
+        try {
+          ValidationUtil.validateCentralDocs(testTypes);
+        } catch (error) {
+          expect(error).toBeInstanceOf(HTTPError);
+          expect(error.statusCode).toBe(400);
+          expect(error.body).toBe(
+            `Central documents can not be issued for a test status of fail`,
           );
-          try {
-              ValidationUtil.validateCentralDocs(testTypes);
-          } catch (error) {
-              expect(error).toBeInstanceOf(HTTPError);
-              expect(error.statusCode).toBe(400);
-              expect(error.body).toBe(
-                  `Central documents can not be issued for a test status of fail`,
-              );
-          }
-        });
+        }
+      });
     });
   });
   describe('IVA Defects', () => {

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3251,20 +3251,30 @@ describe('insertTestResult', () => {
           expect(validationResult).toBe(true);
         });
 
-        it('should throw a validation error when reasons for issue is not present', () => {
+        it('should throw a validation error when reasons for issue is missing', () => {
           testResult.testTypes[0].centralDocs = {
             issueRequired: true,
-            reasonsForIssue: ['reason'],
           } as any;
-          const validationResult =
-            ValidationUtil.validateInsertTestResultPayload(testResult);
-          expect(validationResult).toBe(true);
+
+          expect(() =>
+            ValidationUtil.validateInsertTestResultPayload(testResult),
+          ).toThrow(HTTPError);
+
+          try {
+              ValidationUtil.validateInsertTestResultPayload(testResult);
+          } catch (err) {
+            const error = err as HTTPError;
+            expect(error.statusCode).toBe(400);
+            expect(error.body.errors[0]).toBe(
+                '"testTypes[0].centralDocs.reasonsForIssue" is required',
+            );
+          }
         });
 
         it('should throw a validation error when issue required is missing', () => {
           testResult.testTypes[0].centralDocs = {
-            issueRequired: true,
             notes: 'notes',
+            reasonsForIssue: ['reason'],
           } as any;
 
           expect(() =>
@@ -3277,7 +3287,7 @@ describe('insertTestResult', () => {
             const error = err as HTTPError;
             expect(error.statusCode).toBe(400);
             expect(error.body.errors[0]).toBe(
-              '"testTypes[0].centralDocs.reasonsForIssue" is required',
+              '"testTypes[0].centralDocs.issueRequired" is required',
             );
           }
         });

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3250,6 +3250,18 @@ describe('insertTestResult', () => {
           expect(validationResult).toBe(true);
         });
 
+        it('should create the record successfully when all present and test result fail', () => {
+          testResult.testTypes[0].centralDocs = {
+             issueRequired: true,
+             notes: 'notes',
+             reasonsForIssue: ['reason'],
+          };
+          testResult.testTypes[0].testResult = 'fail';
+          const validationResult =
+              ValidationUtil.validateInsertTestResultPayload(testResult);
+          expect(validationResult).toBe(true);
+        });
+
         it('should throw a validation error when reasons for issue is missing', () => {
           testResult.testTypes[0].centralDocs = {
             issueRequired: true,
@@ -3428,30 +3440,6 @@ describe('insertTestResult', () => {
           expect(error.statusCode).toBe(400);
           expect(error.body).toBe(
             `Central documents can not be issued for test type 1`,
-          );
-        }
-      });
-
-      it('should throw for valid type but invalid test result', () => {
-        const testResultFail = {
-          ...testResultsPostMock[15],
-        } as ITestResultPayload;
-        testResultFail.testTypes[0].testResult = 'fail';
-        testResultFail.testTypes[0].centralDocs = {
-          issueRequired: true,
-          reasonsForIssue: [],
-        };
-        const testTypes = [testResultFail.testTypes[0]];
-        expect(() => ValidationUtil.validateCentralDocs(testTypes)).toThrow(
-          HTTPError,
-        );
-        try {
-          ValidationUtil.validateCentralDocs(testTypes);
-        } catch (error) {
-          expect(error).toBeInstanceOf(HTTPError);
-          expect(error.statusCode).toBe(400);
-          expect(error.body).toBe(
-            `Central documents can not be issued for a test status of fail`,
           );
         }
       });

--- a/tests/unit/insertTestResult.unitTest.ts
+++ b/tests/unit/insertTestResult.unitTest.ts
@@ -3239,7 +3239,7 @@ describe('insertTestResult', () => {
           expect(validationResult).toBe(true);
         });
 
-        it('should create the record successfully when notes and reason for issue are present', () => {
+        it('should create the record successfully when notes and reasons for issue are present', () => {
           testResult.testTypes[0].centralDocs = {
             issueRequired: true,
             notes: 'notes',
@@ -3293,8 +3293,35 @@ describe('insertTestResult', () => {
       });
 
       describe('when submitting a valid test without central docs present', () => {
-        it('should create the record successfully', () => {
+        it('should create the record successfully for a test type id not in the list and status of pass or prs', () => {
           testResult.testTypes[0].testTypeId = '1';
+          delete testResult.testTypes[0].centralDocs;
+          const validationResult =
+            ValidationUtil.validateInsertTestResultPayload(testResult);
+          expect(validationResult).toBe(true);
+        });
+
+        it('should create the record successfully for a test type id not in the list and status of fail', () => {
+          testResult.testTypes[0].testTypeId = '1';
+          testResult.testTypes[0].testResult = 'fail';
+          delete testResult.testTypes[0].centralDocs;
+          const validationResult =
+            ValidationUtil.validateInsertTestResultPayload(testResult);
+          expect(validationResult).toBe(true);
+        });
+
+        it('should create the record successfully for a test type id in the list with status of pass or prs', () => {
+          testResult.testTypes[0].testTypeId = '41';
+          testResult.testTypes[0].testResult = 'prs';
+          delete testResult.testTypes[0].centralDocs;
+          const validationResult =
+            ValidationUtil.validateInsertTestResultPayload(testResult);
+          expect(validationResult).toBe(true);
+        });
+
+        it('should create the record successfully for a test type id in the list with status of fail', () => {
+          testResult.testTypes[0].testTypeId = '41';
+          testResult.testTypes[0].testResult = 'fail';
           delete testResult.testTypes[0].centralDocs;
           const validationResult =
             ValidationUtil.validateInsertTestResultPayload(testResult);


### PR DESCRIPTION
## Amend Central Docs object validation to be optional

[CB2-13369](https://dvsa.atlassian.net/browse/CB2-13369)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
